### PR TITLE
New image for buildwheels

### DIFF
--- a/buildwheels.sh
+++ b/buildwheels.sh
@@ -13,7 +13,7 @@ set -xeuo pipefail
 if ! grep -q docker /proc/1/cgroup; then
   # We are not inside a container
   docker pull quay.io/pypa/manylinux1_x86_64
-  exec docker run --rm -v $(pwd):/io quay.io/pypa/manylinux1_x86_64 /io/$0
+  exec docker run --rm -v $(pwd):/io quay.io/pypa/manylinux2010_x86_64 /io/$0
 fi
 
 # Strip binaries (copied from multibuild)


### PR DESCRIPTION
Hi,

I tried cythonizing [fastqsplitter](https://github.com/LUMC/fastqsplitter/pull/6) because I was not happy with the overhead of the python runtime for such a simple job.

Basically all the cythonizing packaging worked except that I could not upload wheels because I did not have the infrastructure set up. Can I have permission to use your buildwheels.sh script? (You will be properly attributed of course). The demo script by PYPA did not work out of the box.

Also I found out that the `quay.io/pypa/manylinux1_x86_64` image does not work at all (at least on my machine). With the 2010 image it works fine again and it  creates all the necessary wheels. So I made this PR in case you run into the same problem.

Best regards,
Ruben 