### PR TITLE
Adding Power support(ppc64le) with ci and testing to the project for architecture independent

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,9 @@ language: python
 cache:
   directories:
     - $HOME/.cache/pip
-
+arch:
+ - amd64
+ - ppc64le
 python:
   - "3.6"
   - "3.7"
@@ -52,6 +54,34 @@ jobs:
     - stage: test
       name: mypy
       python: "3.6"
+      install: python3 -m pip install mypy .
+      script: mypy src/
+  
+    - stage: deploy
+      arch: ppc64le
+      services:
+        - docker
+      python: "3.6"
+      install: python3 -m pip install Cython twine
+      if: tag IS present
+      script:
+        - |
+          python3 setup.py sdist
+          ./buildwheels.sh
+          ls -l dist/
+          python3 -m twine upload dist/*
+
+    - stage: test
+      name: flake8
+      arch: ppc64le
+      python: "3.6"
+      install: python3 -m pip install flake8
+      script: flake8 src/ tests/
+
+    - stage: test
+      name: mypy
+      python: "3.6"
+      arch: ppc64le
       install: python3 -m pip install mypy .
       script: mypy src/
 


### PR DESCRIPTION
I am working for IBM to port cpu arch ppc64le for open sources.

This PR adds CI support for the IBM Power Little Endian (ppc64le) architecture. The idea is to ensure that the builds on this architecture are continuously tested along with the Intel builds (amd64) as this is part of the ubuntu distro 
on that architecture as well and detecting (and fixing) any issues or failures early would help to ensure that we are always up to date.,For more info tag @gerrith3.

please note mypy is failing in both cpu arch amd64 and ppc64le ,.
Please help to verify and merge.