### PR TITLE
Add more explanation about the decode('latin-1') speed advantage

### DIFF
--- a/src/dnaio/_core.pyx
+++ b/src/dnaio/_core.pyx
@@ -268,6 +268,11 @@ def fastq_iter(file, sequence_class, Py_ssize_t buffer_size):
             name_length = pos - endskip - record_start - 1
             name_encoded = c_buf + record_start + 1
             # .decode('latin-1') is 50% faster than .decode('ascii')
+            # This is because PyUnicode_DecodeLatin1 is an alias for
+            # _PyUnicode_FromUCS1. Which directly copies the bytes into a
+            # string object. No operations are taking place. With
+            # PyUnicode_DecodeASCII, all characters are checked whether they
+            # exceed 128.
             name = c_buf[record_start+1:pos-endskip].decode('latin-1')
 
             pos += 1

--- a/src/dnaio/_core.pyx
+++ b/src/dnaio/_core.pyx
@@ -93,6 +93,11 @@ cdef class Sequence:
         into a file."""
         # Convert to ASCII bytes sequences first as these have a one-to-one
         # relation between size and number of bytes
+        # Unlike decoding, ascii is not slower than latin-1. This is because
+        # CPython performs a call to PyUnicodeCheck on both occassions. This
+        # determines the type of the Unicode object. In fact, the ascii encode
+        # is slightly faster because the check for PyASCIIObject is performed
+        # first.
         cdef bytes name = self.name.encode('ascii')
         cdef bytes sequence = self.sequence.encode('ascii')
         cdef bytes qualities = self.qualities.encode('ascii')


### PR DESCRIPTION
I checked if `.decode('ascii')` could be used as a shorthand to check whether these strings are valid ASCII. It is possible but it comes at a speed disadvantage

```
Benchmark #1: python dnaio_read.py ~/test/big2.fastq
  Time (mean ± σ):      1.958 s ±  0.050 s    [User: 1.843 s, System: 0.114 s]
  Range (min … max):    1.918 s …  2.094 s    10 runs

Benchmark #1: python dnaio_read.py ~/test/big2.fastq
  Time (mean ± σ):      2.311 s ±  0.076 s    [User: 2.196 s, System: 0.115 s]
  Range (min … max):    2.256 s …  2.507 s    10 runs
 
```
I dived deeper in the Python code and put my findings in the comments as to why this is.


