### PR TITLE
Improve parser performance

### DIFF
--- a/src/dnaio/_core.pyx
+++ b/src/dnaio/_core.pyx
@@ -217,7 +217,9 @@ def fastq_iter(file, sequence_class, Py_ssize_t buffer_size):
         Py_ssize_t second_header_length, name_length
         Py_ssize_t name_start, name_end, second_header_end, sequence_end
         Py_ssize_t qualities_end
-        cdef char *name_end_ptr, *sequence_end_ptr, *second_header_end_ptr
+        cdef char *name_end_ptr
+        cdef char *sequence_end_ptr
+        cdef char *second_header_end_ptr
         cdef char *qualities_end_ptr
         bint custom_class = sequence_class is not Sequence
         Py_ssize_t n_records = 0

--- a/src/dnaio/_core.pyx
+++ b/src/dnaio/_core.pyx
@@ -327,9 +327,7 @@ def fastq_iter(file, sequence_class, Py_ssize_t buffer_size):
                 qualities_end -= 1
 
             name_length = name_end - name_start
-            sequence_length = sequence_end - sequence_start
             second_header_length = second_header_end - second_header_start
-            qualities_length = qualities_end - qualities_start
 
             if second_header_length:  # should be 0 when only + is present
                 second_header = True

--- a/src/dnaio/_core.pyx
+++ b/src/dnaio/_core.pyx
@@ -338,7 +338,6 @@ def fastq_iter(file, sequence_class, Py_ssize_t buffer_size):
             second_header_length = second_header_end - second_header_start
 
             if second_header_length:  # should be 0 when only + is present
-                second_header = True
                 if (name_length != second_header_length or
                         strncmp(c_buf+second_header_start,
                             c_buf + name_start, second_header_length) != 0):
@@ -349,8 +348,6 @@ def fastq_iter(file, sequence_class, Py_ssize_t buffer_size):
                             c_buf[name_start:name_end].decode('latin-1'),
                             c_buf[second_header_start:second_header_end]
                             .decode('latin-1')), line=n_records * 4 + 2)
-            else:
-                second_header = False
 
             ### Copy record into python variables
             # .decode('latin-1') is 50% faster than .decode('ascii')
@@ -364,7 +361,7 @@ def fastq_iter(file, sequence_class, Py_ssize_t buffer_size):
             qualities = c_buf[qualities_start:qualities_end].decode('latin-1')
 
             if n_records == 0:
-                yield second_header  # first yielded value is special
+                yield bool(second_header_length)  # first yielded value is special
             if custom_class:
                 yield sequence_class(name, sequence, qualities)
             else:

--- a/src/dnaio/_core.pyx
+++ b/src/dnaio/_core.pyx
@@ -209,16 +209,15 @@ def fastq_iter(file, sequence_class, Py_ssize_t buffer_size):
         bytearray buf = bytearray(buffer_size)
         char[:] buf_view = buf
         char* c_buf = buf
-        int endskip
         str name
-        char* name_encoded
+        str sequence
+        str qualities
         Py_ssize_t last_read_position = 0
         Py_ssize_t record_start = 0
-        Py_ssize_t bufstart, bufend, sequence_start
-        Py_ssize_t second_header_start, sequence_length, qualities_start
-        Py_ssize_t second_header_length, name_length
-        Py_ssize_t name_start, name_end, second_header_end, sequence_end
-        Py_ssize_t qualities_end
+        Py_ssize_t bufstart, bufend, name_start, name_end, name_length
+        Py_ssize_t sequence_start, sequence_end, sequence_length
+        Py_ssize_t second_header_start, second_header_end, second_header_length
+        Py_ssize_t qualities_start, qualities_end, qualities_length
         cdef char *name_end_ptr
         cdef char *sequence_end_ptr
         cdef char *second_header_end_ptr

--- a/src/dnaio/_core.pyx
+++ b/src/dnaio/_core.pyx
@@ -277,7 +277,9 @@ def fastq_iter(file, sequence_class, Py_ssize_t buffer_size):
         record_start = 0
         while True:
             ### Check for a complete record (i.e 4 newlines are present)
-            # Use libc memchr, as some libc functions will be implemented in assembly
+            # Use libc memchr, this optimizes looking for characters by
+            # using 64-bit integers. See:
+            # https://sourceware.org/git/?p=glibc.git;a=blob_plain;f=string/memchr.c;hb=HEAD
             # void *memchr(const void *str, int c, size_t n)
             name_end_ptr = <char *>memchr(c_buf + record_start, 10, <size_t>(bufend - record_start))
             if name_end_ptr == NULL or name_end_ptr == bufend_ptr:

--- a/tests/test_internal.py
+++ b/tests/test_internal.py
@@ -239,7 +239,7 @@ class TestFastqReader:
             list(fq)
 
     def test_second_header_not_equal(self):
-        fastq = BytesIO(b'@r1\nACG\n+xy\n')
+        fastq = BytesIO(b'@r1\nACG\n+xy\nXXX\n')
         with raises(FastqFormatError) as info:
             with FastqReader(fastq) as fq:
                 list(fq)  # pragma: no cover


### PR DESCRIPTION
Hi. I have been looking at this code for more than 3 years, and finally I find a way to improve the performance. This consists of two commits, of which you may choose to merge only one.

### Base performance
```
Benchmark #1: python dnaio_read.py ~/test/big2.fastq
  Time (mean ± σ):      2.080 s ±  0.018 s    [User: 1.956 s, System: 0.123 s]
  Range (min … max):    2.055 s …  2.105 s    10 runs
```

### Improve code layout

Commit one groups similar functionality in the parse code. This makes the code easier to read. As well as limits the amount of '+1', '-1', etc. actions. We don't create new name, sequence and qualities variables until it is certain that the FASTQ record has the complete 4 newlines.
This code is slightly faster (5-10% in my benchmarks). Maybe this has also to do with the branch predictor in the CPU having an easier time because similar functionality is grouped. (EDIT: Or this may be the layout issue mentioned below in which case it is a very small increment probably)
```
Benchmark #1: python dnaio_read.py ~/test/big2.fastq
  Time (mean ± σ):      1.878 s ±  0.014 s    [User: 1.769 s, System: 0.109 s]
  Range (min … max):    1.855 s …  1.907 s    10 runs
```

### Infer quality length from sequence length

I was reading [joelonsoftware.com's article on microsoft office formats](https://www.joelonsoftware.com/2008/02/19/why-are-the-microsoft-office-file-formats-so-complicated-and-some-workarounds/), and he noted that binary formats are much easier to read, because you can simply copy whole parts in memory directly. That is also what happens in this parser, which is good. I was lamenting that it is unfortunate that we do not know the length beforehand because FASTQ does not encode that.

Then I realized the spec says that the qualities string MUST be the length of the sequence string. So it **does** encode one length.

For each character in the input, two checks were performed. Is it a newline, and have we reached bufend yet?
With this change the length of the quality string is inferred from the sequence string. Therefore we can skip
sequence length x 2 checks. We just perform checks afterward to see if we end on a newline.

This has a slight risk, as there are some possible outcomes:
1. The newline is indeed the last newline of the record.
2. The newline is a newline in a following record, because the quality string was truncated and we were unlucky.

In case of 1. Success, but in case of 2. there are two possible outcomes:
a. It is the ending newline of the name, sequence or second header line.
   In which case the parser will throw an error for the next record.
   Which is good, problem averted.
b. It is the ending newline of the next record's quality string. In that case
   we have included an entire record in this record's quality string and the
   parser keeps happily parsing.

In case of b, this leads to a missing record, and a record with
invalid quality values. This might be catched by upstream tools
(problem averted!) or even by cutadapt itself (in paired mode), or it will lead to wrong quality values for this record.
Probably one misrepresented record will not lead to a different analysis outcome.
 If there are multiple records with an erroneous quality length, they are bound to be not lucky all the time and trigger parser erros.

So with this commit we sacrifice fidelty in an extremely rare edge case error for speed.  Dnaio does this all the time though: quality and sequence are not checked for if the characters are in the valid ASCII range. So this is in the spirit of the project. EDIT: to better phrase this. Garbage in == garbage out. With this code change the ability is lost to catch one very rare case of garbage. With correct input the output will still always be correct.

And now the speed improvement:

```
Benchmark #1: python dnaio_read.py ~/test/big2.fastq
  Time (mean ± σ):      1.310 s ±  0.017 s    [User: 1.182 s, System: 0.128 s]
  Range (min … max):    1.278 s …  1.338 s    10 runs
``` 

### Disclaimer

Compiling C is prone to layout problems which can make the performance differ as much as 40%. See this very interesting video below. I did not benchmark this change with the rigor as shown in this video. However because the code changes do demonstrably less work each, I think the performance gains are real.
https://www.youtube.com/watch?v=7g1Acy5eGbE

EDIT: After deleting two unused variables for instance after recompilation the speed improvement is:
```
Benchmark #1: python dnaio_read.py ~/test/big2.fastq
  Time (mean ± σ):      1.462 s ±  0.019 s    [User: 1.331 s, System: 0.130 s]
  Range (min … max):    1.438 s …  1.502 s    10 runs
```
Still good, but a 150 ms difference!  For compiler and layout things that are not easy to fix.