### PR TITLE
Add _needs_stub attribute to allow pip install .

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,10 @@ class BuildExt(build_ext):
             # only sensible thing is to require Cython to be installed.
             from Cython.Build import cythonize
             self.extensions = cythonize(self.extensions)
+            # Setuptools build_meta requires a _needs_stub attribute.
+            # This is required for `pip install .`
+            for i in range(len(self.extensions)):
+                setattr(self.extensions[i], "_needs_stub", False)
         super().run()
 
 


### PR DESCRIPTION
I had some trouble with `pip install .`. This fixes that. I use `pip install .` quite a lot for benchmarks.

EDIT: for python-isal I also had this issue and fixed it this way. Eventually I simply gave up and always required cython installed. With the new-style packages this is quite doable.
The cythonization therefore no longer happens in build_ext, but in the top-level setup.py. This has the advantage of being able to set project-wide compiler directives. (Although that is not relevant for this project with only one cython file).