### PR TITLE
Move length check to __init__ method of sequence

### DIFF
--- a/src/dnaio/_core.pyx
+++ b/src/dnaio/_core.pyx
@@ -34,11 +34,13 @@ cdef class Sequence:
         self.sequence = sequence
         self.qualities = qualities
 
+    def __init__(self, str name, str sequence, str qualities = None):
+        # __cinit__ is called first and sets all the variables.
         if qualities is not None and len(qualities) != len(sequence):
             rname = shorten(name)
             raise ValueError("In read named {!r}: length of quality sequence "
-                "({}) and length of read ({}) do not match".format(
-                    rname, len(qualities), len(sequence)))
+                             "({}) and length of read ({}) do not match".format(
+                rname, len(qualities), len(sequence)))
 
     def __getitem__(self, key):
         """


### PR DESCRIPTION
When calling `__new__`, the `__cinit__` method is called, but the `__init__` method is not. Since we have already checked the length of the sequence in the `fastq_iter` method there is no need to check the length again in the `__cinit__` method.

This speeds up the parsing slightly (benchmarks in conjunction with #14):
before:
```
Benchmark #1: python dnaio_read.py ~/test/big2.fastq
  Time (mean ± σ):      1.081 s ±  0.023 s    [User: 966.8 ms, System: 114.1 ms]
  Range (min … max):    1.041 s …  1.147 s    50 runs
```
after:
```
Benchmark #1: python dnaio_read.py ~/test/big2.fastq
  Time (mean ± σ):      1.050 s ±  0.027 s    [User: 938.7 ms, System: 111.4 ms]
  Range (min … max):    1.003 s …  1.121 s    50 runs
```

The speed increase is small but many small changes can amount to something.