### PR TITLE
Decrease buffer size to 128KiB to improve performance when reading from pipes.

### DIFF
--- a/src/dnaio/readers.py
+++ b/src/dnaio/readers.py
@@ -121,7 +121,7 @@ class FastqReader(BinaryFileReader, SingleEndReader):
         file: Union[str, BinaryIO],
         *,
         sequence_class=Sequence,
-        buffer_size: int = 1048576,
+        buffer_size: int = 128 * 1024,  # Buffer size used by cat, pigz etc.
         opener=xopen,
         _close_file: Optional[bool] = None,
     ):


### PR DESCRIPTION
Sorry for the PR spam. I found some minor things in the code that each should be considered in isolation.

This is the size used by cat and pigz to read files. This uses less memory. No performance impact on normal files. Faster on reading from pipes.

before:
```
Benchmark #1: python dnaio_read.py ~/test/big2.fastq
  Time (mean ± σ):      2.075 s ±  0.031 s    [User: 1.953 s, System: 0.122 s]
  Range (min … max):    2.012 s …  2.145 s    20 runs
```
After:
```
Benchmark #1: python dnaio_read.py ~/test/big2.fastq
  Time (mean ± σ):      2.067 s ±  0.021 s    [User: 1.946 s, System: 0.121 s]
  Range (min … max):    2.030 s …  2.113 s    20 runs
 ```

Gzip files:
Before:
```
Benchmark #1: python dnaio_read.py ~/test/big2.fastq.gz
  Time (mean ± σ):      3.417 s ±  0.045 s    [User: 5.089 s, System: 0.560 s]
  Range (min … max):    3.342 s …  3.487 s    10 runs
```
After
```
python dnaio_read.py ~/test/big2.fastq.gz
  Time (mean ± σ):      3.264 s ±  0.035 s    [User: 5.061 s, System: 0.567 s]
  Range (min … max):    3.219 s …  3.322 s 
```

This is because xopen opens the gzip file in PipedReader mode. With a max pipesize of 1 MB. If the one MB is read entirely while the pipe is not entirely full there might be blocking. This does not happen when reading smaller chunks.

 Also 128 KiB is used by `cat` and `pigz`. These are very good programs.