### PR TITLE
Modernize setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,21 @@ jobs:
     - name: Run tox ${{ matrix.toxenv }}
       run: tox -e ${{ matrix.toxenv }}
 
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0  # required for setuptools_scm
+    - name: Set up Python 3.7
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.7
+    - name: Install dependencies
+      run: python -m pip install build
+    - name: Build temporary sdist and wheel
+      run: python -m build
+
   test:
     timeout-minutes: 5
     runs-on: ${{ matrix.os }}
@@ -47,7 +62,7 @@ jobs:
   deploy:
     timeout-minutes: 5
     runs-on: ubuntu-latest
-    needs: [lint, test]
+    needs: [lint, test, build]
     if: startsWith(github.ref, 'refs/tags')
     steps:
     - uses: actions/checkout@v2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,3 +4,6 @@ build-backend = "setuptools.build_meta"
 
 [black.tool]
 line-length = 100
+
+[tool.setuptools_scm]
+write_to = "src/dnaio/_version.py"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools", "wheel", "setuptools_scm", "Cython"]
+requires = ["setuptools >= 45", "wheel", "setuptools_scm >= 6.2", "Cython >= 0.29.20"]
 build-backend = "setuptools.build_meta"
 
 [black.tool]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,35 @@
+[metadata]
+name = dnaio
+author = Marcel Martin
+author_email = marcel.martin@scilifelab.se
+url = https://github.com/marcelm/dnaio/
+description = Read and write FASTA and FASTQ files efficiently
+long_description = file: README.md
+long_description_content_type = text/markdown
+license = MIT
+classifiers =
+    Development Status :: 5 - Production/Stable
+    Intended Audience :: Science/Research
+    License :: OSI Approved :: MIT License
+    Programming Language :: Cython
+    Programming Language :: Python :: 3
+    Topic :: Scientific/Engineering :: Bio-Informatics
+
+[options]
+python_requires = >=3.6
+package_dir =
+    =src
+packages = find:
+install_requires =
+    xopen >= 0.8.2
+
+[options.packages.find]
+where = src
+
+[options.package_data]
+* = py.typed, *.pyi
+
+[options.extras_require]
+dev =
+    Cython
+    pytest

--- a/setup.py
+++ b/setup.py
@@ -1,81 +1,11 @@
-import os.path
-from setuptools import setup, Extension, find_packages
-from setuptools.command.sdist import sdist
-from setuptools.command.build_ext import build_ext
-
-
-def no_cythonize(extensions, **_ignore):
-    """Change .pyx to .c or .cpp (copied from Cython documentation)"""
-    for extension in extensions:
-        sources = []
-        for sfile in extension.sources:
-            path, ext = os.path.splitext(sfile)
-            if ext in ('.pyx', '.py'):
-                if extension.language == 'c++':
-                    ext = '.cpp'
-                else:
-                    ext = '.c'
-                sfile = path + ext
-            sources.append(sfile)
-        extension.sources[:] = sources
-
-
-class BuildExt(build_ext):
-    def run(self):
-        # If we encounter a PKG-INFO file, then this is likely a .tar.gz/.zip
-        # file retrieved from PyPI that already includes the pre-cythonized
-        # extension modules, and then we do not need to run cythonize().
-        if os.path.exists('PKG-INFO'):
-            no_cythonize(self.extensions)
-        else:
-            # Otherwise, this is a 'developer copy' of the code, and then the
-            # only sensible thing is to require Cython to be installed.
-            from Cython.Build import cythonize
-            self.extensions = cythonize(self.extensions)
-        super().run()
-
-
-class SDist(sdist):
-    def run(self):
-        # Make sure the compiled Cython files in the distribution are up-to-date
-        from Cython.Build import cythonize
-        cythonize(self.distribution.ext_modules)
-        super().run()
-
-
-with open('README.md', encoding='utf-8') as f:
-    long_description = f.read()
+from setuptools import setup, Extension
+from Cython.Build import cythonize
+import setuptools_scm  # noqa  Ensure it’s installed
 
 setup(
-    name='dnaio',
-    setup_requires=['setuptools_scm'],  # Support pip versions that don't know about pyproject.toml
-    use_scm_version={'write_to': 'src/dnaio/_version.py'},
-    author='Marcel Martin',
-    author_email='marcel.martin@scilifelab.se',
-    url='https://github.com/marcelm/dnaio/',
-    description='Read and write FASTA and FASTQ files efficiently',
-    long_description=long_description,
-    long_description_content_type='text/markdown',
-    license='MIT',
-    package_dir={'': 'src'},
-    packages=find_packages('src'),
-    package_data={"dnaio": ["py.typed", "*.pyi"]},
-    extras_require={
-        'dev': ['Cython', 'pytest'],
-    },
-    ext_modules=[
-        Extension('dnaio._core', sources=['src/dnaio/_core.pyx']),
-    ],
-    cmdclass={'build_ext': BuildExt, 'sdist': SDist},
-    install_requires=['xopen>=0.8.2'],
-    python_requires='>=3.6',
-    classifiers=[
-            "Development Status :: 5 - Production/Stable",
-            "Intended Audience :: Science/Research",
-            "License :: OSI Approved :: MIT License",
-            "Natural Language :: English",
-            "Programming Language :: Cython",
-            "Programming Language :: Python :: 3",
-            "Topic :: Scientific/Engineering :: Bio-Informatics"
-    ]
+    ext_modules=cythonize(
+        [
+            Extension("dnaio._core", sources=["src/dnaio/_core.pyx"]),
+        ]
+    ),
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,6 @@
 [tox]
 envlist = flake8,mypy,py36,py37,py38,py39
-requires =
-    Cython>=0.29.13
-    setuptools_scm
+isolated_build = True
 
 [testenv]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,8 @@
 [tox]
 envlist = flake8,mypy,py36,py37,py38,py39
-requires = Cython>=0.29.13
+requires =
+    Cython>=0.29.13
+    setuptools_scm
 
 [testenv]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = flake8,mypy,py36,py37,py38,py39
+envlist = flake8,mypy,py36,py37,py38,py39,py310
 isolated_build = True
 
 [testenv]


### PR DESCRIPTION
- Move metadata to `setup.cfg`
- Add a CI test that runs `python -m build`, which will build the sdist and create a wheel from it. This ensures that the sdist contains all files necessary to build the wheel
- Expect Cython to be installed at build time and just always call `cythonize()`. Because of this, there’s no need for custom `build_ext` nor `sdist` classes anymore.
- With `isolated_build = True` in `tox.ini`, the build dependencies only need to specify once, in `pyproject.toml`.

I made most of these changes previously in WhatsHap, see https://github.com/whatshap/whatshap/pull/344, and also in Cutadapt.

Supercedes #16