### PR TITLE
Increase speed of name matching for paired end reads.

### DIFF
--- a/src/dnaio/_core.pyx
+++ b/src/dnaio/_core.pyx
@@ -399,17 +399,16 @@ def record_names_match(header1: str, header2: str):
     # find the spaces and tabs easily.
     cdef char * header1chars = <char *>PyUnicode_1BYTE_DATA(header1)
     cdef char * header2chars = <char *>PyUnicode_1BYTE_DATA(header2)
-    return record_name_bytes_match(header1chars, header2chars, len(header1), len(header2))
+    return record_name_bytes_match(header1chars, header2chars)
 
 
-cdef bint record_name_bytes_match(
-    char *header1chars, char *header2chars,
-    Py_ssize_t header1length, Py_ssize_t header2length):
+cdef bint record_name_bytes_match(char *header1chars, char *header2chars):
     """
     Check whether the ascii-encoded names match.
     """
     # Only the first part (i.e. the name without the comment) is of interest.
-    # Find the first tab or space.
+    # Find the first tab or space, if not present, strcspn will return the
+    # position of the terminating NULL byte. (I.e. the length).
     cdef size_t header1_ends = strcspn(header1chars, b' \t')
     cdef size_t header2_ends = strcspn(header2chars, b' \t')
     # Quick check if the lengths match

--- a/src/dnaio/_core.pyx
+++ b/src/dnaio/_core.pyx
@@ -443,6 +443,4 @@ cdef size_t whitespace_at(unsigned char *str_ptr, size_t length):
     tab_ptr = <unsigned char *>memchr(str_ptr, b'\t', space_at)
     if tab_ptr == NULL:
         return space_at
-    if tab_ptr < space_ptr:
-        return tab_ptr - str_ptr
-    return space_at
+    return tab_ptr - str_ptr

--- a/tests/test_internal.py
+++ b/tests/test_internal.py
@@ -482,6 +482,11 @@ class TestPairedSequenceReader:
         assert match('abc def', 'abc ghi')
         assert match('abc', 'abc ghi')
         assert not match('abc', 'xyz')
+        assert match('abc\tdef', 'abc')
+        assert match('abc\tdef', 'abc\tghi')
+        assert match('abc somecomment\tanothercomment', 'abc andanothercomment\tbla')
+        assert match('abc\tcomments comments', 'abc\tothers others')
+        assert match('abc\tdef', 'abc def')
 
     def test_record_names_match_with_ignored_trailing_12(self):
         match = record_names_match


### PR DESCRIPTION
I noticed that paired end reading incurs a heavy performance penalty
Baseline:
```
Benchmark #1: python dnaio_read_paired.py ~/test/big2.fastq
  Time (mean ± σ):      5.693 s ±  0.026 s    [User: 5.480 s, System: 0.213 s]
  Range (min … max):    5.650 s …  5.737 s    10 runs
```
Given that in single-end mode it runs in 2.1 seconds, this is quite heavy. 
So I disabled the namecheck to see what the difference would be:
```
Benchmark #1: python dnaio_read_paired.py ~/test/big2.fastq
  Time (mean ± σ):      4.491 s ±  0.025 s    [User: 4.268 s, System: 0.223 s]
  Range (min … max):    4.443 s …  4.538 s    10 runs
```
So that is roughly 1.3 seconds extra. Just for the name checking. That is rather suboptimal. We can parse the entire file again in that time.  (NOTE that this PR originates from main, not the pending speed improvements.)

So this PR improves the speed of the name comparison. 

+ It checks if the strings are stored as 1-byte data. (They should be!). It throws a ValueError if not.
+ Then it retrieves a char pointer to the unicode buffer.
+ Since it is 1-byte data we know that space == 32 and that tab == 9. Use memchr to look for both space and tab.
+ Compare the unicode buffers. We use the length until the first space or tab character, or the entire length if there is no whitespace.

I also did a naive implementation where I checked every character individually for space and tab and also compared the header1 and header2 character, but that was significantly slower than using memchr on the entire string twice to find tab or space and then using memcmp on the entire string.

The result:
```
Benchmark #1: python dnaio_read_paired.py ~/test/big2.fastq
  Time (mean ± σ):      4.786 s ±  0.027 s    [User: 4.570 s, System: 0.215 s]
  Range (min … max):    4.733 s …  4.820 s    10 runs
```

So we now only spent 300 ms for the name checking. Far more acceptable.

EDIT: I just realized that we can also use this PyUnicode_1BYTE_DATA macro to make the writing of FASTQ records quite a lot faster. But I will implement that after this PR is merged.
