### PR TITLE
Use zip_longest for more readable and faster code in the paired end iterator

### DIFF
--- a/src/dnaio/pairedend.py
+++ b/src/dnaio/pairedend.py
@@ -54,19 +54,19 @@ class TwoFilePairedEndReader(PairedEndReader):
         # but it will take a long time for 3.10 or higher to be available on
         # everyone's machine.
         # Instead use zip_longest from itertools. This yields None if one of
-        # the iterators is exhausted. Checking for truthy values is speedy.
+        # the iterators is exhausted. Checking for None identity is fast.
         # So we can quickly check if the iterator is still yielding.
         # This is faster than implementing a while loop with next calls,
         # which requires expensive function lookups.
         it1, it2 = iter(self.reader1), iter(self.reader2)
         for r1, r2 in itertools.zip_longest(it1, it2):
-            if not r1:
+            if r1 is None:
                 raise FileFormatError(
                     "Reads are improperly paired. There are more reads in "
                     "file 2 than in file 1.",
                     line=None,
                 ) from None
-            if not r2:
+            if r2 is None:
                 raise FileFormatError(
                     "Reads are improperly paired. There are more reads in "
                     "file 1 than in file 2.",

--- a/src/dnaio/pairedend.py
+++ b/src/dnaio/pairedend.py
@@ -58,8 +58,7 @@ class TwoFilePairedEndReader(PairedEndReader):
         # So we can quickly check if the iterator is still yielding.
         # This is faster than implementing a while loop with next calls,
         # which requires expensive function lookups.
-        it1, it2 = iter(self.reader1), iter(self.reader2)
-        for r1, r2 in itertools.zip_longest(it1, it2):
+        for r1, r2 in itertools.zip_longest(self.reader1, self.reader2):
             if r1 is None:
                 raise FileFormatError(
                     "Reads are improperly paired. There are more reads in "

--- a/tests/test_internal.py
+++ b/tests/test_internal.py
@@ -521,6 +521,15 @@ class TestPairedSequenceReader:
                 list(psr)
         assert "There are more reads in file 1 than in file 2" in info.value.message
 
+    def test_empty_sequences_do_not_stop_iteration(self):
+        s1 = BytesIO(b'@r1_1\nACG\n+\nHHH\n@r2_1\nACG\n+\nHHH\n@r3_2\nACG\n+\nHHH\n')
+        s2 = BytesIO(b'@r1_1\nACG\n+\nHHH\n@r2_2\n\n+\n\n@r3_2\nACG\n+\nHHH\n')
+        # Second sequence for s2 is empty but valid. Should not lead to a stop of iteration.
+        with TwoFilePairedEndReader(s1, s2) as psr:
+            seqs = list(psr)
+        print(seqs)
+        assert len(seqs) == 3
+
     def test_incorrectly_paired(self):
         s1 = BytesIO(b'@r1/1\nACG\n+\nHHH\n')
         s2 = BytesIO(b'@wrong_name\nTTT\n+\nHHH\n')


### PR DESCRIPTION
Sorry for the PR spam. I just suddenly find so much stuff to optimize in this library. And even more is coming, but that depends on still pending PRs #14 and #20. (I want to make writing faster still, by avoiding creating new bytes objects).

This is an easy one to review. I know you are busy!

Ideally we would want to use `zip(it1, it2, strict=True)`, but that is only available from python 3.10 and higher. (3.9 on my Debian 11 machine).

Since try ... except has some expense I tried using `next` differently. It has a default argument. So you can use `next(it1, None)` and it will yield None if the iterator is exhausted. This leads to a cleaner looking code when checking.

I had a look at itertools if there was something in the standard library, and yes there was: zip_longest. Keeps on yielding until the longest iterator is exhausted and yields None for the shortest iterator. 

The code looks cleaner now now all the exhaustion checking is in zip_longest instead of in try except loops. As an added bonus, itertools is fully implemented in C so it is faster as well:

before:
```
Benchmark #1: python dnaio_read_paired.py ~/test/big2.fastq
  Time (mean ± σ):      4.884 s ±  0.031 s    [User: 4.667 s, System: 0.216 s]
  Range (min … max):    4.826 s …  4.919 s    10 runs
 ```
after
```
Benchmark #1: python dnaio_read_paired.py ~/test/big2.fastq
  Time (mean ± σ):      4.746 s ±  0.049 s    [User: 4.540 s, System: 0.206 s]
  Range (min … max):    4.691 s …  4.835 s    10 runs
```

It is 2-3% faster. Not bad for such a small change.