### PR TITLE
Support Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   lint:
-    timeout-minutes: 5
+    timeout-minutes: 10
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -16,7 +16,7 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
+    - name: Install tox
       run: python -m pip install tox
     - name: Run tox ${{ matrix.toxenv }}
       run: tox -e ${{ matrix.toxenv }}
@@ -35,58 +35,69 @@ jobs:
         path: dist/*.tar.gz
 
   test:
-    timeout-minutes: 5
+    timeout-minutes: 10
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
         os: [ubuntu-latest]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
         include:
-        - python-version: 3.8
-          os: macos-latest
-        - python-version: 3.8
-          os: windows-latest
+        - os: macos-latest
+          python-version: 3.8
+        - os: windows-latest
+          python-version: 3.8
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
+    - name: Install tox
       run: python -m pip install tox
     - name: Test
       run: tox -e py
     - name: Upload coverage report
       uses: codecov/codecov-action@v1
 
-  deploy:
-    timeout-minutes: 5
-    runs-on: ubuntu-latest
-    needs: [lint, test, build]
-    if: startsWith(github.ref, 'refs/tags')
+  wheels:
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+    needs: [lint, test]
+    timeout-minutes: 10
+    strategy:
+      matrix:
+        os: [ubuntu-20.04, windows-2019]
+    runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2
       with:
         fetch-depth: 0  # required for setuptools_scm
     - name: Build wheels
-      uses: pypa/cibuildwheel@v2.1.1
-      with:
-        output-dir: dist/
+      uses: pypa/cibuildwheel@v2.1.2
       env:
-        CIBW_BUILD: "cp3*-manylinux_x86_64"
-        CIBW_MANYLINUX_X86_64_IMAGE: manylinux2010
+        CIBW_BUILD: "cp*-manylinux_x86_64 cp3*-win_amd64"
         CIBW_ENVIRONMENT: "CFLAGS=-g0"
-    - name: Set up Python
-      uses: actions/setup-python@v2
+        CIBW_TEST_REQUIRES: "pytest"
+        CIBW_TEST_COMMAND: "pytest {project}/tests"
+    - uses: actions/upload-artifact@v2
       with:
-        python-version: 3.7
-    - name: Make distributions
-      run: |
-        python -m pip install build
-        python -m build --sdist
-        ls -l dist/
+        name: wheels
+        path: wheelhouse/*.whl
+
+  publish:
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+    needs: [build, wheels]
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/download-artifact@v2
+      with:
+        name: sdist
+        path: dist/
+    - uses: actions/download-artifact@v2
+      with:
+        name: wheels
+        path: dist/
     - name: Publish to PyPI
-      uses: pypa/gh-action-pypi-publish@v1.4.1
+      uses: pypa/gh-action-pypi-publish@v1.4.2
       with:
         user: __token__
         password: ${{ secrets.pypi_password }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
   wheels:
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
     needs: [lint, test]
-    timeout-minutes: 10
+    timeout-minutes: 15
     strategy:
       matrix:
         os: [ubuntu-20.04, windows-2019]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,8 @@ jobs:
         CIBW_BUILD: "cp*-manylinux_x86_64 cp3*-win_amd64"
         CIBW_ENVIRONMENT: "CFLAGS=-g0"
         CIBW_TEST_REQUIRES: "pytest"
-        CIBW_TEST_COMMAND: "pytest {project}/tests"
+        CIBW_TEST_COMMAND_LINUX: "cd {project} && pytest tests"
+        CIBW_TEST_COMMAND_WINDOWS: "cd /d {project} && pytest tests"
     - uses: actions/upload-artifact@v2
       with:
         name: wheels

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,25 +27,25 @@ jobs:
     - uses: actions/checkout@v2
       with:
         fetch-depth: 0  # required for setuptools_scm
-    - name: Set up Python 3.7
-      uses: actions/setup-python@v2
+    - name: Build sdist and temporary wheel
+      run: pipx run build
+    - uses: actions/upload-artifact@v2
       with:
-        python-version: 3.7
-    - name: Install dependencies
-      run: python -m pip install build
-    - name: Build temporary sdist and wheel
-      run: python -m build
+        name: sdist
+        path: dist/*.tar.gz
 
   test:
     timeout-minutes: 5
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, "3.10"]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
         os: [ubuntu-latest]
         include:
         - python-version: 3.8
           os: macos-latest
+        - python-version: 3.8
+          os: windows-latest
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,7 @@ package_dir =
     =src
 packages = find:
 install_requires =
-    xopen >= 0.8.2
+    xopen >= 1.4.0
 
 [options.packages.find]
 where = src

--- a/src/dnaio/singleend.py
+++ b/src/dnaio/singleend.py
@@ -116,6 +116,7 @@ def _detect_format_from_content(file: BinaryIO) -> Optional[str]:
         first_char = file.read(1)
         file.seek(original_position)
     else:
+        # We cannot always use peek() because BytesIO objects do not suppert it
         first_char = file.peek(1)[0:1]  # type: ignore
     formats = {
         b"@": "fastq",

--- a/src/dnaio/singleend.py
+++ b/src/dnaio/singleend.py
@@ -112,9 +112,9 @@ def _detect_format_from_content(file: BinaryIO) -> Optional[str]:
     Return 'fasta', 'fastq' or None
     """
     if file.seekable():
+        original_position = file.tell()
         first_char = file.read(1)
-        if file.tell() > 0:
-            file.seek(-1, 1)
+        file.seek(original_position)
     else:
         first_char = file.peek(1)[0:1]  # type: ignore
     formats = {

--- a/tests/test_internal.py
+++ b/tests/test_internal.py
@@ -555,8 +555,11 @@ def test_read_stdin(path):
     with dnaio.open(path) as f:
         expected = len(list(f))
 
-    # Use 'cat' to simulate that no file name is available for stdin of the subprocess
-    with subprocess.Popen(['cat', path], stdout=subprocess.PIPE) as cat:
+    # Use piping from a separate subprocess to force the input file name to be unavailable
+    cmd = "type" if sys.platform == "win32" else "cat"
+    with subprocess.Popen(
+        [cmd, path], stdout=subprocess.PIPE, shell=sys.platform == "win32"
+    ) as cat:
         with subprocess.Popen(
             [sys.executable, 'tests/read_from_stdin.py'], stdin=cat.stdout, stdout=subprocess.PIPE
         ) as py:

--- a/tests/test_internal.py
+++ b/tests/test_internal.py
@@ -545,10 +545,10 @@ class TestPairedSequenceReader:
 
 
 @mark.parametrize('path', [
-    'tests/data/simple.fastq',
-    'tests/data/dos.fastq',
-    'tests/data/simple.fasta',
-    'tests/data/with_comment.fasta',
+    os.path.join('tests', 'data', 'simple.fastq'),
+    os.path.join('tests', 'data', 'dos.fastq'),
+    os.path.join('tests', 'data', 'simple.fasta'),
+    os.path.join('tests', 'data', 'with_comment.fasta'),
 ])
 def test_read_stdin(path):
     # Get number of records in the input file


### PR DESCRIPTION
- The GitHub Actions job that created the wheels needed to become a matrix job that runs on Windows and Linux. Because the sdist was also created in that job and I did not want it to be created multiple times, sdist creation, wheel creation and publishing are now separate jobs.
- `pipx` is installed on the Linux runners, so building the sdist could be simplified to `pipx run build` (and to test whether a wheel can be created from the sdist, I do not add the `--sdist` option).
- The other changes were just the things necessary to make the code work on both platforms.
- The Windows tests should no longer fail as soon as https://github.com/pycompression/xopen/pull/83 is merged and a new xopen version is published.