### PR TITLE
Construct unicode objects with PyUnicode_New

### DIFF
--- a/src/dnaio/_core.pyx
+++ b/src/dnaio/_core.pyx
@@ -1,5 +1,6 @@
 # cython: language_level=3, emit_code_comments=False
 
+from cpython.ref cimport PyObject
 from cpython.bytes cimport PyBytes_FromStringAndSize, PyBytes_AS_STRING, PyBytes_GET_SIZE
 from cpython.unicode cimport PyUnicode_DecodeLatin1
 from libc.string cimport strncmp, memcmp, memcpy, memchr, strcspn
@@ -388,10 +389,12 @@ def fastq_iter(file, sequence_class, Py_ssize_t buffer_size):
             # Constructing objects with PyUnicode_New and memcpy bypasses some of
             # the checks otherwise done when using PyUnicode_DecodeLatin1 or similar
             name = PyUnicode_New(name_length, 255)
-            memcpy(PyUnicode_1BYTE_DATA(name), c_buf + name_start, name_length)
             sequence = PyUnicode_New(sequence_length, 255)
-            memcpy(PyUnicode_1BYTE_DATA(sequence), c_buf + sequence_start, sequence_length)
             qualities = PyUnicode_New(qualities_length, 255)
+            if <PyObject*>name == NULL or <PyObject*>sequence == NULL or <PyObject*>qualities == NULL:
+                raise MemoryError()
+            memcpy(PyUnicode_1BYTE_DATA(name), c_buf + name_start, name_length)
+            memcpy(PyUnicode_1BYTE_DATA(sequence), c_buf + sequence_start, sequence_length)
             memcpy(PyUnicode_1BYTE_DATA(qualities), c_buf + qualities_start, qualities_length)
 
             if n_records == 0:

--- a/src/dnaio/_core.pyx
+++ b/src/dnaio/_core.pyx
@@ -10,6 +10,7 @@ cdef extern from *:
     unsigned char * PyUnicode_1BYTE_DATA(object o)
     int PyUnicode_KIND(object o)
     int PyUnicode_1BYTE_KIND
+    object PyUnicode_New(Py_ssize_t size, Py_UCS4 maxchar)
 from .exceptions import FastqFormatError
 from ._util import shorten
 
@@ -384,15 +385,14 @@ def fastq_iter(file, sequence_class, Py_ssize_t buffer_size):
                 raise FastqFormatError(
                     "Length of sequence and qualities differ", line=n_records * 4 + 3)
 
-            ### Copy record into python variables
-            # PyUnicode_DecodeLatin1 is 50% faster than PyUnicode_DecodeASCII.
-            # This is because PyUnicode_DecodeLatin1 is an alias for
-            # _PyUnicode_FromUCS1. Which directly copies the bytes into a
-            # string object after some checks. With PyUnicode_DecodeASCII,
-            # there is an extra check whether characters exceed 128.
-            name = PyUnicode_DecodeLatin1(c_buf + name_start, name_length, 'strict')
-            sequence = PyUnicode_DecodeLatin1(c_buf + sequence_start, sequence_length, 'strict')
-            qualities = PyUnicode_DecodeLatin1(c_buf + qualities_start, qualities_length, 'strict')
+            # Constructing objects with PyUnicode_New and memcpy bypasses some of
+            # the checks otherwise done when using PyUnicode_DecodeLatin1 or similar
+            name = PyUnicode_New(name_length, 255)
+            memcpy(PyUnicode_1BYTE_DATA(name), c_buf + name_start, name_length)
+            sequence = PyUnicode_New(sequence_length, 255)
+            memcpy(PyUnicode_1BYTE_DATA(sequence), c_buf + sequence_start, sequence_length)
+            qualities = PyUnicode_New(qualities_length, 255)
+            memcpy(PyUnicode_1BYTE_DATA(qualities), c_buf + qualities_start, qualities_length)
 
             if n_records == 0:
                 yield bool(second_header_length)  # first yielded value is special

--- a/src/dnaio/_core.pyx
+++ b/src/dnaio/_core.pyx
@@ -2,7 +2,6 @@
 
 from cpython.ref cimport PyObject
 from cpython.bytes cimport PyBytes_FromStringAndSize, PyBytes_AS_STRING, PyBytes_GET_SIZE
-from cpython.unicode cimport PyUnicode_DecodeLatin1
 from libc.string cimport strncmp, memcmp, memcpy, memchr, strcspn
 from cpython.unicode cimport PyUnicode_GET_LENGTH
 cimport cython


### PR DESCRIPTION
This avoids some of the overhead of calling `PyUnicode_DecodeLatin1` by creating the unicode object with an unitialized buffer and then copying the data into it.

On my test data, this gives a ~9% speedup for the `for r in dnaio.open("r.fastq"): pass` loop (2.42 seconds to 2.20 seconds).

This is marked as draft because PyUnicode_New can return NULL, in which case we need to raise a `MemoryError()` (this is also done incorrectly in some other places in the code).

I have no idea whether this is done correctly. For example, `PyUnicode_New` actually returns a `PyObject*`, but I only got it to work by declaring it as returning `object`.