### PR TITLE
Fix parsing of FASTA files that contain a comment and no reads

### DIFF
--- a/src/dnaio/chunks.py
+++ b/src/dnaio/chunks.py
@@ -16,7 +16,7 @@ def _fasta_head(buf: bytes, end: Optional[int] = None) -> int:
     pos = buf.rfind(b'\n>', 0, end)
     if pos != -1:
         return pos + 1
-    if buf[0:1] == b'>':
+    if buf[0:1] == b'>' or buf[0:1] == b'#':
         return 0
     if len(buf) == 0:
         return 0

--- a/src/dnaio/chunks.py
+++ b/src/dnaio/chunks.py
@@ -58,15 +58,19 @@ def read_chunks(f: RawIOBase, buffer_size: int = 4 * 1024**2) -> Iterator[memory
     # Read one byte to determine file format.
     # If there is a comment char, we assume FASTA!
     start = f.readinto(memoryview(buf)[0:1])
-    if start == 1 and buf[0:1] == b'@':
-        head = _fastq_head
-    elif start == 1 and (buf[0:1] == b'#' or buf[0:1] == b'>'):
-        head = _fasta_head
-    elif start == 0:
+    if start == 0:
         # Empty file
         return
+    assert start == 1
+    if buf[0:1] == b'@':
+        head = _fastq_head
+    elif buf[0:1] == b'#' or buf[0:1] == b'>':
+        head = _fasta_head
     else:
-        raise UnknownFileFormat('Input file format unknown')
+        raise UnknownFileFormat(
+            f"Cannnot determine input file format: First character expected to be '>' or '@', "
+            f"but found {repr(chr(buf[0]))}"
+        )
 
     # Layout of buf
     #

--- a/src/dnaio/chunks.py
+++ b/src/dnaio/chunks.py
@@ -18,6 +18,8 @@ def _fasta_head(buf: bytes, end: Optional[int] = None) -> int:
         return pos + 1
     if buf[0:1] == b'>':
         return 0
+    if len(buf) == 0:
+        return 0
     c = chr(buf[0])
     raise FastaFormatError(
         f"FASTA file expected to start with '>', but found {repr(c)}",

--- a/src/dnaio/chunks.py
+++ b/src/dnaio/chunks.py
@@ -18,7 +18,11 @@ def _fasta_head(buf: bytes, end: Optional[int] = None) -> int:
         return pos + 1
     if buf[0:1] == b'>':
         return 0
-    raise FastaFormatError('File does not start with ">"', line=None)
+    c = chr(buf[0])
+    raise FastaFormatError(
+        f"FASTA file expected to start with '>', but found {repr(c)}",
+        line=None,
+    )
 
 
 def _fastq_head(buf: bytes, end: Optional[int] = None) -> int:

--- a/tests/test_chunks.py
+++ b/tests/test_chunks.py
@@ -2,7 +2,33 @@ from pytest import raises
 from io import BytesIO
 
 from dnaio._core import paired_fastq_heads
-from dnaio.chunks import _fastq_head, read_chunks, read_paired_chunks
+from dnaio.chunks import _fastq_head, _fasta_head, read_chunks, read_paired_chunks
+
+
+def test_fasta_head():
+    assert _fasta_head(b'') == 0
+    assert _fasta_head(b'>1\n') == 0
+    assert _fasta_head(b'>1\n3') == 0
+    assert _fasta_head(b'>1\n3\n') == 0
+    assert _fasta_head(b'>1\n3\n>') == 5
+    assert _fasta_head(b'>1\n3\n>6') == 5
+    assert _fasta_head(b'>1\n3\n>6\n') == 5
+    assert _fasta_head(b'>1\n3\n>6\n8') == 5
+    assert _fasta_head(b'>1\n3\n>6\n8\n') == 5
+    assert _fasta_head(b'>1\n3\n>6\n8\n0') == 5
+    assert _fasta_head(b'>1\n3\n>6\n8\n0\n') == 5
+    assert _fasta_head(b'>1\n3\n>6\n8\n0\n>') == 12
+
+
+def test_fasta_head_with_comment():
+    assert _fasta_head(b'#') == 0
+    assert _fasta_head(b'#\n') == 0
+    assert _fasta_head(b'#\n>') == 2
+    assert _fasta_head(b'#\n>3') == 2
+    assert _fasta_head(b'#\n>3\n') == 2
+    assert _fasta_head(b'#\n>3\n5') == 2
+    assert _fasta_head(b'#\n>3\n5\n') == 2
+    assert _fasta_head(b'#\n>3\n5\n>') == 7
 
 
 def test_paired_fastq_heads():


### PR DESCRIPTION
See https://github.com/marcelm/cutadapt/issues/591.

The FASTA parser allows comment lines in FASTA (starting with `#`), but the `_fasta_head` function does not take this into account.

This also makes some error messages somewhat more informative.