### PR TITLE
Do not ship C file in source distribution

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,3 @@
 include README.md
 include LICENSE
-include src/dnaio/*.c
 include src/dnaio/_version.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools >= 45", "wheel", "setuptools_scm >= 6.2", "Cython >= 0.29.20"]
+requires = ["setuptools >= 52", "wheel", "setuptools_scm >= 6.2", "Cython >= 0.29.20"]
 build-backend = "setuptools.build_meta"
 
 [black.tool]

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,8 +22,7 @@ package_dir =
 packages = find:
 install_requires =
     xopen >= 1.4.0
-setup_requires =
-    cython >= 0.29.20
+
 [options.packages.find]
 where = src
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,7 +22,8 @@ package_dir =
 packages = find:
 install_requires =
     xopen >= 1.4.0
-
+setup_requires =
+    cython >= 0.29.20
 [options.packages.find]
 where = src
 

--- a/setup.py
+++ b/setup.py
@@ -2,8 +2,7 @@ from setuptools import setup, Extension
 import setuptools_scm  # noqa  Ensure it’s installed
 
 setup(
-    ext_modules=
-        [
-            Extension("dnaio._core", sources=["src/dnaio/_core.pyx"]),
-        ],
+    ext_modules=[
+        Extension("dnaio._core", sources=["src/dnaio/_core.pyx"]),
+    ],
 )

--- a/setup.py
+++ b/setup.py
@@ -6,5 +6,4 @@ setup(
         [
             Extension("dnaio._core", sources=["src/dnaio/_core.pyx"]),
         ],
-    setup_requires=["cython >=0.29.20"]
 )

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,10 @@
 from setuptools import setup, Extension
-from Cython.Build import cythonize
 import setuptools_scm  # noqa  Ensure it’s installed
 
 setup(
-    ext_modules=cythonize(
+    ext_modules=
         [
             Extension("dnaio._core", sources=["src/dnaio/_core.pyx"]),
-        ]
-    ),
+        ],
+    setup_requires=["cython >=0.29.20"]
 )


### PR DESCRIPTION
fixes #50 

This removes the `cythonize` command from setup.py. Cythonize gives more control over how to cythonize extensions, but this is already covered in the `_core.pyx` file itself as it has the compiler_directives set there.

The disadvantage of `cythonize` is that it converts a cython extension into a distutils.Extension. In other words a normal C-extension. Therefore setuptools thinks that the C-source should be included. 

Setuptools.Extension however does recognize `.pyx` files and will convert them to C files itself. So there is no need for cythonize. By this way setuptools realizes that the source file is not the C file but the `.pyx` file and will therefore only include the pyx file.

I also struck the C file from the manifest. Both the Setuptools.Extension and the MANIFEST.in deletion where needed to remove the C file.

This reduces the size of the sdist from 92,3KB to 33,1KB