### PR TITLE
MANIFEST.in is not needed

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,0 @@
-include README.md
-include LICENSE
-include src/dnaio/_version.py


### PR DESCRIPTION
When setuptools_scm is installed, it provides some kind of a "file finder" plugin for setuptools that includes all files under version control in the sdist.

This is somewhat suprising to me, but we might as well rely on that behavior.

`src/dnaio/_version.py` is explicitly gitignore-d, but I tested it and saw that it is included in the sdist.

Also, `README.md` was incorrect anyway as we renamed the file to `README.rst` recently.