### PR TITLE
Branchless checking for ASCII

### DIFF
--- a/src/dnaio/ascii_check.h
+++ b/src/dnaio/ascii_check.h
@@ -7,33 +7,28 @@
 static int
 string_is_ascii(char * string, size_t length) {
     size_t n = length;
+    uint64_t all_chars = 0;
     char * char_ptr = string;
     // The first loop aligns the memory address. Char_ptr is cast to a size_t
     // to return the memory address. Uint64_t is 8 bytes long, and the processor
     // handles this better when its address is a multiplier of 8. This loops
     // handles the first few bytes that are not on such a multiplier boundary.
     while ((size_t)char_ptr % sizeof(uint64_t) && n != 0) {
-        if (*char_ptr & ASCII_MASK_1BYTE) {
-            return 0;
-        }
+        all_chars |= *char_ptr;
         char_ptr += 1;
         n -= 1;
     }
     uint64_t *longword_ptr = (uint64_t *)char_ptr;
     while (n >= sizeof(uint64_t)) {
-        if (*longword_ptr & ASCII_MASK_8BYTE){
-            return 0;
-        }
+        all_chars |= *longword_ptr;
         longword_ptr += 1;
         n -= sizeof(uint64_t);
     }
     char_ptr = (char *)longword_ptr;
     while (n != 0) {
-        if (*char_ptr & ASCII_MASK_1BYTE) {
-            return 0;
-        }
+        all_chars |= *char_ptr;
         char_ptr += 1;
         n -= 1;
     }
-    return 1;
+    return !(all_chars & ASCII_MASK_8BYTE);
 }


### PR DESCRIPTION
This is 20% faster for the ascii check. But 20% faster on something that is not a bottleneck is not really noticable. Still, I don't like wasting compute cycles and this makes the code simpler and without branches. 

I have been fiddling a bit with the ascii-check repo. I also added an SSE2 implementation in that repo. SSE2 in particular is a **very** interesting instruction set because **all** x86-64 CPUs support it. No exceptions. So it can always be included in the x86-64 builds. 

That implementation cuts the ASCII checking time in more than half, so that might be interesting to look at. I will add that later after this is merged.
 
