### PR TITLE
Avoid some "unclosed file" ResourceWarnings

### DIFF
--- a/src/dnaio/readers.py
+++ b/src/dnaio/readers.py
@@ -136,10 +136,16 @@ class FastqReader(BinaryFileReader, SingleEndReader):
         self.sequence_class = sequence_class
         self.delivers_qualities = True
         self.buffer_size = buffer_size
-        # The first value yielded by FastqIter indicates
-        # whether the file has repeated headers
-        self._iter: Iterator[SequenceRecord] = FastqIter(self._file, self.sequence_class, self.buffer_size)
         try:
+            self._iter: Iterator[SequenceRecord] = FastqIter(
+                self._file, self.sequence_class, self.buffer_size
+            )
+        except Exception:
+            self.close()
+            raise
+        try:
+            # The first value yielded by FastqIter indicates
+            # whether the file has repeated headers
             th = next(self._iter)
             assert isinstance(th, bool)
             self.two_headers: bool = th

--- a/src/dnaio/readers.py
+++ b/src/dnaio/readers.py
@@ -80,6 +80,7 @@ class FastaReader(BinaryFileReader, SingleEndReader):
         self.delivers_qualities = False
         self._delimiter = '\n' if keep_linebreaks else ''
         self.number_of_records = 0
+        self._file = io.TextIOWrapper(self._file)
 
     def __iter__(self) -> Iterator[SequenceRecord]:
         """
@@ -89,8 +90,7 @@ class FastaReader(BinaryFileReader, SingleEndReader):
         seq: List[str] = []
         if self._file.closed:
             return
-        f = io.TextIOWrapper(self._file)
-        for i, line in enumerate(f):
+        for i, line in enumerate(self._file):
             # strip() also removes DOS line breaks
             line = line.strip()
             if not line:
@@ -112,8 +112,6 @@ class FastaReader(BinaryFileReader, SingleEndReader):
         if name is not None:
             self.number_of_records += 1
             yield self.sequence_class(name, self._delimiter.join(seq), None)
-        # Prevent TextIOWrapper from closing the underlying file
-        f.detach()
 
 
 class FastqReader(BinaryFileReader, SingleEndReader):

--- a/tests/test_internal.py
+++ b/tests/test_internal.py
@@ -82,7 +82,8 @@ class TestFastaReader:
         filename = "tests/data/simple.fasta"
         with open(filename, 'rb') as f:
             assert not f.closed
-            _ = list(dnaio.open(f))
+            with dnaio.open(f) as inner_f:
+                list(inner_f)
             assert not f.closed
         assert f.closed
 

--- a/tests/test_open.py
+++ b/tests/test_open.py
@@ -97,6 +97,12 @@ def test_read_opener(fileformat, extension):
     assert records[0].sequence == "ACG"
 
 
+def test_read_paired_fasta():
+    path = "tests/data/simple.fasta"
+    with dnaio.open(file1=path, file2=path) as f:
+        list(f)
+
+
 @pytest.mark.parametrize("interleaved", [False, True])
 def test_paired_opener(fileformat, extension, interleaved):
     def my_opener(_path, _mode):


### PR DESCRIPTION
This should fix the test failures in marcelm/cutadapt#609.

Possibly we should start to treat these warnings as errors just as in Cutadapt. I was a bit undisciplined with closing files in Cutadapt in the beginning, but then this actually led to truncated files that a user reported. Since then, I try to heed these warnings and close everything properly (so not relying on automatic cleanup at process termination).