### PR TITLE
Small pointer refactor and cleanup

### DIFF
--- a/src/dnaio/_core.pyx
+++ b/src/dnaio/_core.pyx
@@ -9,12 +9,12 @@ from libc.string cimport memcmp, memcpy, memchr, strcspn, memmove
 cimport cython
 
 cdef extern from "Python.h":
-    void * PyUnicode_DATA(object o)
+    void *PyUnicode_DATA(object o)
     bint PyUnicode_IS_COMPACT_ASCII(object o)
     object PyUnicode_New(Py_ssize_t size, Py_UCS4 maxchar)
 
 cdef extern from "ascii_check.h":
-    int string_is_ascii(char * string, size_t length)
+    int string_is_ascii(char *string, size_t length)
 
 cdef extern from "_conversions.h":
     const char NUCLEOTIDE_COMPLEMENTS[256]
@@ -190,9 +190,9 @@ cdef class SequenceRecord:
             raise ValueError("Cannot create a FASTQ record when qualities is not set.")
 
         cdef:
-            char * name = <char *>PyUnicode_DATA(self._name)
-            char * sequence = <char *>PyUnicode_DATA(self._sequence)
-            char * qualities = <char *>PyUnicode_DATA(self._qualities)
+            char *name = <char *>PyUnicode_DATA(self._name)
+            char *sequence = <char *>PyUnicode_DATA(self._sequence)
+            char *qualities = <char *>PyUnicode_DATA(self._qualities)
             size_t name_length = <size_t>PyUnicode_GET_LENGTH(self._name)
             size_t sequence_length = <size_t>PyUnicode_GET_LENGTH(self._sequence)
             size_t qualities_length = <size_t>PyUnicode_GET_LENGTH(self._qualities)
@@ -207,7 +207,7 @@ cdef class SequenceRecord:
 
         # This is the canonical way to create an uninitialized bytestring of given size
         cdef bytes retval = PyBytes_FromStringAndSize(NULL, total_size)
-        cdef char * retval_ptr = PyBytes_AS_STRING(retval)
+        cdef char *retval_ptr = PyBytes_AS_STRING(retval)
 
         # Write the sequences into the bytestring at the correct positions.
         cdef size_t cursor
@@ -252,9 +252,9 @@ cdef class SequenceRecord:
             bool: Whether this and *other* are part of the same read pair.
         """
         cdef:
-            char * header1_chars = <char *>PyUnicode_DATA(self._name)
+            char *header1_chars = <char *>PyUnicode_DATA(self._name)
             size_t header1_length = <size_t> PyUnicode_GET_LENGTH(self._name)
-            char * header2_chars = <char *>PyUnicode_DATA(other._name)
+            char *header2_chars = <char *>PyUnicode_DATA(other._name)
         return record_ids_match(header1_chars, header2_chars, header1_length)
 
     def reverse_complement(self):
@@ -262,10 +262,10 @@ cdef class SequenceRecord:
             Py_ssize_t sequence_length = PyUnicode_GET_LENGTH(self._sequence)
             object reversed_sequence_obj = PyUnicode_New(sequence_length, 127)
             object reversed_qualities_obj
-            char * reversed_sequence = <char *>PyUnicode_DATA(reversed_sequence_obj)
-            char * sequence = <char *>PyUnicode_DATA(self._sequence),
-            char * reversed_qualities
-            char * qualities
+            char *reversed_sequence = <char *>PyUnicode_DATA(reversed_sequence_obj)
+            char *sequence = <char *>PyUnicode_DATA(self._sequence),
+            char *reversed_qualities
+            char *qualities
             Py_ssize_t cursor, reverse_cursor
             unsigned char nucleotide
         reverse_cursor = sequence_length
@@ -304,15 +304,15 @@ def paired_fastq_heads(buf1, buf2, Py_ssize_t end1, Py_ssize_t end2):
 
     cdef:
         Py_ssize_t linebreaks = 0
-        char * data1 = <char *>data1_buffer.buf
-        char * data2 = <char *>data2_buffer.buf
+        char *data1 = <char *>data1_buffer.buf
+        char *data2 = <char *>data2_buffer.buf
         # The min() function ensures we do not read beyond the size of the buffer.
-        char * data1_end = data1 + min(end1, data1_buffer.len)
-        char * data2_end = data2 + min(end2, data2_buffer.len)
-        char * pos1 = data1
-        char * pos2 = data2
-        char * record_start1 = data1
-        char * record_start2 = data2
+        char *data1_end = data1 + min(end1, data1_buffer.len)
+        char *data2_end = data2 + min(end2, data2_buffer.len)
+        char *pos1 = data1
+        char *pos2 = data2
+        char *record_start1 = data1
+        char *record_start2 = data2
 
     while True:
         pos1 = <char *>memchr(pos1, b'\n', data1_end - pos1)
@@ -452,15 +452,15 @@ cdef class FastqIter:
     def __next__(self):
         cdef:
             object ret_val
-            char * name_start
-            char * name_end
-            char * sequence_start
-            char * sequence_end
-            char * second_header_start
-            char * second_header_end
-            char * qualities_start
-            char * qualities_end
-            char * buffer_end
+            char *name_start
+            char *name_end
+            char *sequence_start
+            char *sequence_end
+            char *second_header_start
+            char *second_header_end
+            char *qualities_start
+            char *qualities_end
+            char *buffer_end
             Py_ssize_t name_length, sequence_length, second_header_length, qualities_length
         # Repeatedly attempt to parse the buffer until we have found a full record.
         # If an attempt fails, we read more data before retrying.
@@ -574,8 +574,8 @@ def record_names_match(header1: str, header2: str):
     Deprecated, use `SequenceRecord.is_mate` instead
     """
     cdef:
-        char * header1_chars = NULL
-        char * header2_chars = NULL
+        char *header1_chars = NULL
+        char *header2_chars = NULL
         size_t header1_length
     if PyUnicode_CheckExact(header1):
         if PyUnicode_IS_COMPACT_ASCII(header1):

--- a/src/dnaio/_core.pyx
+++ b/src/dnaio/_core.pyx
@@ -9,7 +9,6 @@ from libc.string cimport memcmp, memcpy, memchr, strcspn, memmove
 cimport cython
 
 cdef extern from "Python.h":
-    unsigned char * PyUnicode_1BYTE_DATA(object o)
     void * PyUnicode_DATA(object o)
     bint PyUnicode_IS_COMPACT_ASCII(object o)
     object PyUnicode_New(Py_ssize_t size, Py_UCS4 maxchar)
@@ -212,9 +211,9 @@ cdef class SequenceRecord:
             raise ValueError("Cannot create a FASTQ record when qualities is not set.")
 
         cdef:
-            char * name = <char *>PyUnicode_1BYTE_DATA(self._name)
-            char * sequence = <char *>PyUnicode_1BYTE_DATA(self._sequence)
-            char * qualities = <char *>PyUnicode_1BYTE_DATA(self._qualities)
+            char * name = <char *>PyUnicode_DATA(self._name)
+            char * sequence = <char *>PyUnicode_DATA(self._sequence)
+            char * qualities = <char *>PyUnicode_DATA(self._qualities)
             size_t name_length = <size_t>PyUnicode_GET_LENGTH(self._name)
             size_t sequence_length = <size_t>PyUnicode_GET_LENGTH(self._sequence)
             size_t qualities_length = <size_t>PyUnicode_GET_LENGTH(self._qualities)
@@ -252,9 +251,9 @@ cdef class SequenceRecord:
             bool: Whether this and *other* are part of the same read pair.
         """
         cdef:
-            char * header1_chars = <char *>PyUnicode_1BYTE_DATA(self._name)
+            char * header1_chars = <char *>PyUnicode_DATA(self._name)
             size_t header1_length = <size_t> PyUnicode_GET_LENGTH(self._name)
-            char * header2_chars = <char *>PyUnicode_1BYTE_DATA(other._name)
+            char * header2_chars = <char *>PyUnicode_DATA(other._name)
         return record_ids_match(header1_chars, header2_chars, header1_length)
 
     def reverse_complement(self):
@@ -580,9 +579,9 @@ cdef class FastqIter:
             qualities = PyUnicode_New(qualities_length, 127)
             if <PyObject*>name == NULL or <PyObject*>sequence == NULL or <PyObject*>qualities == NULL:
                 raise MemoryError()
-            memcpy(PyUnicode_1BYTE_DATA(name), name_start, name_length)
-            memcpy(PyUnicode_1BYTE_DATA(sequence), sequence_start, sequence_length)
-            memcpy(PyUnicode_1BYTE_DATA(qualities), qualities_start, qualities_length)
+            memcpy(PyUnicode_DATA(name), name_start, name_length)
+            memcpy(PyUnicode_DATA(sequence), sequence_start, sequence_length)
+            memcpy(PyUnicode_DATA(qualities), qualities_start, qualities_length)
 
             if self.use_custom_class:
                 ret_val = self.sequence_class(name, sequence, qualities)
@@ -611,7 +610,7 @@ def record_names_match(header1: str, header2: str):
         size_t header1_length
     if PyUnicode_CheckExact(header1):
         if PyUnicode_IS_COMPACT_ASCII(header1):
-            header1_chars = <char *>PyUnicode_1BYTE_DATA(header1)
+            header1_chars = <char *>PyUnicode_DATA(header1)
             header1_length = <size_t> PyUnicode_GET_LENGTH(header1)
         else:
             raise ValueError("header1 must be a valid ASCII-string.")
@@ -621,7 +620,7 @@ def record_names_match(header1: str, header2: str):
 
     if PyUnicode_CheckExact(header2):
         if PyUnicode_IS_COMPACT_ASCII(header2):
-            header2_chars = <char *>PyUnicode_1BYTE_DATA(header2)
+            header2_chars = <char *>PyUnicode_DATA(header2)
         else:
             raise ValueError("header2 must be a valid ASCII-string.")
     else:


### PR DESCRIPTION
This removes some redundant variables as well as making quite a few lines of code shorter. It also reduces the amount of pointer arithmetic. (Much less `self.buffer + some_offset`.) 

Additionally all the "pointer slicing" (was exclusively used in errors) has been replaced with the appropriate calls to PyUnicode_DecodeASCII.

PyUnicode_1BYTE_DATA has been replaced with PyUnicode_DATA. Since we cast the results to `<char *>` anyway
 there is no need for the macro that casts to `Py_UCS1`. 

I also inlined several functions that were previously shared between SequenceRecord and BytesSequenceRecord. Which is now redundant.

I think this makes the code more readable.