### PR TITLE
Version 0.9.1

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,10 +2,10 @@
 Changelog
 =========
 
-v0.9.1 (2022-07-15)
+v0.9.1 (2022-08-01)
 -------------------
 
-* :pr:`85`: Mac OS wheels are now also build as part of the release procedure.
+* :pr:`85`: macOS wheels are now also built as part of the release procedure.
 * :pr:`81`: API documentation improvements and minor code refactors for
   readability.
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,13 @@
 Changelog
 =========
 
+v0.9.1 (2022-07-15)
+-------------------
+
+* :pr:`85`: Mac OS wheels are now also build as part of the release procedure.
+* :pr:`81`: API documentation improvements and minor code refactors for
+  readability.
+
 v0.9.0 (2022-05-17)
 -------------------
 


### PR DESCRIPTION
Hi, I tried to release dnaio on my own since you are on holiday. It seems as I don't have permissions though. (I wanted to push to main and add a v0.9.1 tag). No matter. I think I can help the user by providing the wheel directly. I made this PR so the changelog work does not need to be duplicated. See you after the holiday!