### PR TITLE
Consistently raise FastaFormatError on parse errors

### DIFF
--- a/src/dnaio/exceptions.py
+++ b/src/dnaio/exceptions.py
@@ -43,3 +43,28 @@ class FastaFormatError(FileFormatError):
     """
 
     format = "FASTA"
+
+
+class IsNotAscii(ValueError):
+    """
+    Some part of a FASTA or FASTQ file is not ASCII encoded
+
+    Attributes:
+        field: Description of the field ("name", "sequence", "qualities" or similar)
+            in which non-ASCII characters were found
+        value: Unicode string that was intended to be assigned to the field
+    """
+
+    def __init__(self, field: str, value: str):
+        self.value = value
+        self.field = field
+
+    def __str__(self):
+        detail = ""
+        try:
+            self.value.encode("ascii")
+        except UnicodeEncodeError as e:
+            detail = (
+                f", but found '{self.value[e.start:e.end]}' at position {e.start + 1}"
+            )
+        return f"'{self.field}' in sequence file must be ASCII encoded{detail}"

--- a/src/dnaio/exceptions.py
+++ b/src/dnaio/exceptions.py
@@ -43,28 +43,3 @@ class FastaFormatError(FileFormatError):
     """
 
     format = "FASTA"
-
-
-class IsNotAscii(ValueError):
-    """
-    Some part of a FASTA or FASTQ file is not ASCII encoded
-
-    Attributes:
-        field: Description of the field ("name", "sequence", "qualities" or similar)
-            in which non-ASCII characters were found
-        value: Unicode string that was intended to be assigned to the field
-    """
-
-    def __init__(self, field: str, value: str):
-        self.value = value
-        self.field = field
-
-    def __str__(self):
-        detail = ""
-        try:
-            self.value.encode("ascii")
-        except UnicodeEncodeError as e:
-            detail = (
-                f", but found '{self.value[e.start:e.end]}' at position {e.start + 1}"
-            )
-        return f"'{self.field}' in sequence file must be ASCII encoded{detail}"

--- a/src/dnaio/readers.py
+++ b/src/dnaio/readers.py
@@ -11,7 +11,7 @@ from xopen import xopen
 
 from ._core import FastqIter, SequenceRecord
 from ._util import shorten as _shorten
-from .exceptions import FastaFormatError
+from .exceptions import FastaFormatError, IsNotAscii
 from .interfaces import SingleEndReader
 
 
@@ -104,7 +104,14 @@ class FastaReader(BinaryFileReader, SingleEndReader):
             if line and line[0] == ">":
                 if name is not None:
                     self.number_of_records += 1
-                    yield self.sequence_class(name, self._delimiter.join(seq), None)
+                    try:
+                        yield self.sequence_class(name, self._delimiter.join(seq), None)
+                    except IsNotAscii as e:
+                        raise FastaFormatError(
+                            str(e)
+                            + " (line number refers to record after the problematic one)",
+                            line=i,
+                        )
                 name = line[1:]
                 seq = []
             elif line and line[0] == "#":
@@ -119,7 +126,10 @@ class FastaReader(BinaryFileReader, SingleEndReader):
 
         if name is not None:
             self.number_of_records += 1
-            yield self.sequence_class(name, self._delimiter.join(seq), None)
+            try:
+                yield self.sequence_class(name, self._delimiter.join(seq), None)
+            except IsNotAscii as e:
+                raise FastaFormatError(str(e), line=None)
 
 
 class FastqReader(BinaryFileReader, SingleEndReader):

--- a/src/dnaio/readers.py
+++ b/src/dnaio/readers.py
@@ -11,7 +11,7 @@ from xopen import xopen
 
 from ._core import FastqIter, SequenceRecord
 from ._util import shorten as _shorten
-from .exceptions import FastaFormatError, IsNotAscii
+from .exceptions import FastaFormatError
 from .interfaces import SingleEndReader
 
 
@@ -106,7 +106,7 @@ class FastaReader(BinaryFileReader, SingleEndReader):
                     self.number_of_records += 1
                     try:
                         yield self.sequence_class(name, self._delimiter.join(seq), None)
-                    except IsNotAscii as e:
+                    except ValueError as e:
                         raise FastaFormatError(
                             str(e)
                             + " (line number refers to record after the problematic one)",
@@ -128,7 +128,7 @@ class FastaReader(BinaryFileReader, SingleEndReader):
             self.number_of_records += 1
             try:
                 yield self.sequence_class(name, self._delimiter.join(seq), None)
-            except IsNotAscii as e:
+            except ValueError as e:
                 raise FastaFormatError(str(e), line=None)
 
 


### PR DESCRIPTION
Raise it when an attempt is made to create a SequenceRecord with non-ASCII characters in one of the fields.

This is backwards compatible because `IsNotAscii` is a subclass of `ValueError`, which was previously raised for this type of problem.

Also, catch the exception in the FastaReader and convert it to a FastaFormatError when it occurs.

This will help in solving https://github.com/marcelm/cutadapt/issues/628.