### PR TITLE
Upload again code coverage reports to Codecov.io

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
     - name: Test
       run: tox -e py
     - name: Upload coverage report
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v3
 
   wheels:
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')

--- a/tox.ini
+++ b/tox.ini
@@ -7,8 +7,9 @@ deps =
     pytest
     coverage
 commands =
-    coverage run --concurrency=multiprocessing -m pytest --doctest-modules --pyargs tests/
+    coverage run -m pytest
     coverage combine
+    coverage xml
     coverage report
 setenv = PYTHONDEVMODE = 1
 


### PR DESCRIPTION
I noticed that Codecov.io didn’t have coverage reports. The changes here should make it work again.