### PR TITLE
Allow setting open_threads and compression_level

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,11 @@ vnext
 * :pr:`99`: SequenceRecord initialization is now faster which also provides
   a speed boost to FASTQ iteration. ``SequenceRecord.__new__`` cannot be used
   anymore to initialize `SequenceRecord` objects.
+* :pr:`96`: ``open_threads`` and ``compression_level`` are now added
+  to `~dnaio.open` as arguments. By default dnaio now uses compression level
+  1 and does not utilize external programs to speed up gzip (de)compression.
+* :pr:`87`: `~dnaio.open` can now als open more than two files.
+  The ``file1`` and ``file2`` arguments are now deprecated.
 
 v0.9.1 (2022-08-01)
 -------------------

--- a/src/dnaio/__init__.py
+++ b/src/dnaio/__init__.py
@@ -116,8 +116,8 @@ def open(
         Set to ``'r'`` for reading, ``'w'`` for writing or ``'a'`` for appending.
 
       interleaved:
-        If True, then file1 contains interleaved paired-end data.
-        file2 must be None in this case.
+        If True, then there must be only one file argument that contains
+        interleaved paired-end data.
 
       fileformat:
         If *None*, the file format is autodetected from the file name
@@ -135,7 +135,7 @@ def open(
         - When False (no qualities available), an exception is raised when the
           auto-detected output format is FASTQ.
 
-      opener: A function that is used to open file1 and file2 if they are not
+      opener: A function that is used to open the files if they are not
         already open file-like objects. By default, ``xopen`` is used, which can
         also open compressed file formats.
 

--- a/src/dnaio/__init__.py
+++ b/src/dnaio/__init__.py
@@ -80,7 +80,7 @@ Sequence = SequenceRecord
 
 def open(
     *files: Union[str, PathLike, BinaryIO],
-    file1: Union[str, PathLike, BinaryIO] = None,
+    file1: Optional[Union[str, PathLike, BinaryIO]] = None,
     file2: Optional[Union[str, PathLike, BinaryIO]] = None,
     fileformat: Optional[str] = None,
     interleaved: bool = False,


### PR DESCRIPTION
A very minor addition to the open function, but making it much more convenient. Compatibility with cutadapt is kept.

This fixes #90 . 

Discussion points:
- compresslevel vs compression_level. I think that compresslevel is not a very good abbreviation, on the other hand it is used consistently throughout CPython (and also xopen). Since dnaio is not a compression library I think the non-abbreviated version is better here.
- open_threads 0 by default. As someone who regularly works on a compute cluster I am regularly annoyed by applications that by default use all threads or a lot of them. One reason is that when I start a simple script/program on the login node this shouldn't immediately drain all the CPUs if I haven't told it so. This makes the login node unusable, so in my mind the only sane default is 1 thread, unless "parallel" is in the name of the application. (Pigz thus gets a free pass for wanting to use all threads). The other reason is that extra threads come with extra overhead. Since I usually run several samples at the same time I rather use less total compute time as I can run everything in parallel anyway to drive the wall clock time down. 
 
My opinions on the above are not absolute. As long as the open_threads parameter goes in I can choose a default for my own applications anyway. So I wonder what you think. As some extra information here are the benchmarks:

Running with open_threads 0. Total compute time 2.571 + 0.054 = 2.625
```
Benchmark 1: python dnaio_read.py ~/test/ERR039854.fastq.gz
  Time (mean ± σ):      2.625 s ±  0.085 s    [User: 2.571 s, System: 0.054 s]
  Range (min … max):    2.516 s …  2.748 s    10 runs
``` 

Running with open_threads=1. Decompress process is igzip version 2.30 (the fastest option). Total compute time 2.391 + 0.454 = 2.845
```
Benchmark 1: python dnaio_read.py ~/test/ERR039854.fastq.gz
  Time (mean ± σ):      1.560 s ±  0.035 s    [User: 2.391 s, System: 0.454 s]
  Range (min … max):    1.521 s …  1.626 s    10 runs
 ```

For comparison: reading the uncompressed file. The system time goes up a bit compared to 0 threaded gzip open because the filesystem is queried less on the smaller gzip file.
```
Benchmark 1: python dnaio_read.py ~/test/ERR039854.fastq
  Time (mean ± σ):      1.131 s ±  0.024 s    [User: 1.000 s, System: 0.131 s]
  Range (min … max):    1.107 s …  1.184 s    10 runs
```
 
My conclusion is that there is quite a penalty to be payed for using an external proess in terms of total compute time. This wasn't the case when I had just made python-isal, but by this point it is so optimized that it is much better than piping trough igzip. 