### PR TITLE
Avoid pytest 7.2 warnings

### DIFF
--- a/tests/test_internal.py
+++ b/tests/test_internal.py
@@ -266,10 +266,10 @@ class TestFastqReader:
 
 
 class TestOpen:
-    def setup(self):
+    def setup_method(self):
         self._tmpdir = mkdtemp()
 
-    def teardown(self):
+    def teardown_method(self):
         shutil.rmtree(self._tmpdir)
 
     def test_sequence_reader(self):
@@ -388,11 +388,11 @@ class TestInterleavedReader:
 
 
 class TestFastaWriter:
-    def setup(self):
+    def setup_method(self):
         self._tmpdir = mkdtemp()
         self.path = os.path.join(self._tmpdir, "tmp.fasta")
 
-    def teardown(self):
+    def teardown_method(self):
         shutil.rmtree(self._tmpdir)
 
     def test(self):
@@ -438,11 +438,11 @@ class TestFastaWriter:
 
 
 class TestFastqWriter:
-    def setup(self):
+    def setup_method(self):
         self._tmpdir = mkdtemp()
         self.path = os.path.join(self._tmpdir, "tmp.fastq")
 
-    def teardown(self):
+    def teardown_method(self):
         shutil.rmtree(self._tmpdir)
 
     def test(self):


### PR DESCRIPTION
The warning is:
> PytestRemovedIn8Warning: Support for nose tests is deprecated and will be removed in a future release.
> [...] is using nose-specific method: `setup(self)` To remove this warning, rename it to `setup_method(self)`
> See docs: https://docs.pytest.org/en/stable/deprecations.html#support-for-tests-written-for-nose