### PR TITLE
Faster SequenceRecord initialization.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,12 @@
 Changelog
 =========
 
+vnext
+-------------------
+* :pr:`99`: SequenceRecord initialization is now faster which also provides
+  a speed boost to FASTQ iteration. ``SequenceRecord.__new__`` cannot be used
+  anymore to initialize `SequenceRecord` objects.
+
 v0.9.1 (2022-08-01)
 -------------------
 


### PR DESCRIPTION
Before:

```
Benchmark 1: python dnaio_read.py ~/test/big2.fastq
  Time (mean ± σ):     914.5 ms ±  23.8 ms    [User: 792.7 ms, System: 121.7 ms]
  Range (min … max):   882.0 ms … 950.4 ms    10 runs
```

After:
```
Benchmark 1: python dnaio_read.py ~/test/big2.fastq
  Time (mean ± σ):     752.6 ms ±  14.0 ms    [User: 628.9 ms, System: 123.5 ms]
  Range (min … max):   725.8 ms … 779.4 ms    10 runs
```

The disadvantage is that we break `__new__` for everyone. Is this a problem for cutadapt? `__init__` works fine.

The speed advantage requires some explanation. Using the CPython API there are two methods you can set on your extension class: `tp_new` and `tp_init`. `tp_new` creates the class and `tp_init` initializes it. Most extension classes have however, no dynamic attributes so do not need further initialization. tp_new also accepts arguments and keyword arguments and can therefore be used to set the basic attributes. Therefore some objects such as the python `bytes` object only use the `tp_new` slot.
Also in the Python C-API it is possible to forego the `tp_new` slot entirely and simply initialize objects using `PyObject_New` and set struct members manually.  This is not possible in Cython as Cython needs full control over how objects are initialized (it might add/need extra members to the struct, so it is not possible to preduct this beforehand).

I did some digging and this is how the tp_new function looked before:
```C
static PyObject *__pyx_tp_new_5dnaio_5_core_SequenceRecord(PyTypeObject *t, PyObject *a, PyObject *k) {
  struct __pyx_obj_5dnaio_5_core_SequenceRecord *p;
  PyObject *o;
  if (likely((t->tp_flags & Py_TPFLAGS_IS_ABSTRACT) == 0)) {
    o = (*t->tp_alloc)(t, 0);
  } else {
    o = (PyObject *) PyBaseObject_Type.tp_new(t, __pyx_empty_tuple, 0);
  }
  if (unlikely(!o)) return 0;
  p = ((struct __pyx_obj_5dnaio_5_core_SequenceRecord *)o);
  p->_name = Py_None; Py_INCREF(Py_None);
  p->_sequence = Py_None; Py_INCREF(Py_None);
  p->_qualities = Py_None; Py_INCREF(Py_None);
  if (unlikely(__pyx_pw_5dnaio_5_core_14SequenceRecord_1__cinit__(o, a, k) < 0)) goto bad;
  return o;
  bad:
  Py_DECREF(o); o = 0;
  return NULL;
}
```
As you can see, it always calls the `__cinit__` function which has uses arguments (`a`) and keyword arguments (`k`). Most of what `__cinit__` does is parsing the argument tuple and keyword dict. This is expensive. When `__cinit__` is removed this is the tp_new function.

```C
static PyObject *__pyx_tp_new_5dnaio_5_core_SequenceRecord(PyTypeObject *t, CYTHON_UNUSED PyObject *a, CYTHON_UNUSED PyObject *k) {
  struct __pyx_obj_5dnaio_5_core_SequenceRecord *p;
  PyObject *o;
  if (likely((t->tp_flags & Py_TPFLAGS_IS_ABSTRACT) == 0)) {
    o = (*t->tp_alloc)(t, 0);
  } else {
    o = (PyObject *) PyBaseObject_Type.tp_new(t, __pyx_empty_tuple, 0);
  }
  if (unlikely(!o)) return 0;
  p = ((struct __pyx_obj_5dnaio_5_core_SequenceRecord *)o);
  p->_name = Py_None; Py_INCREF(Py_None);
  p->_sequence = Py_None; Py_INCREF(Py_None);
  p->_qualities = Py_None; Py_INCREF(Py_None);
  return o;
}
```
As you can see, it adds the UNUSED macros to the arguments and keyword arguments. By default it sets everything to `None` which is a waste of resources, but not as much as parsing keyword arguments.

TLDR: I did it! Finally I, managed to make Cython do the most barebones init possible, while still letting Cython do the init and not relying on hacks trough the C-API. This should be stable regardless of any new Cython version going forward.

EDIT: I kept a branch in pure C around. It was very useful for learning some parts of the C-API and asses the maximum capability of our current approach. It performs like this:
```
Benchmark 1: python dnaio_read.py ~/test/big2.fastq
  Time (mean ± σ):     683.2 ms ±  19.7 ms    [User: 565.2 ms, System: 117.7 ms]
  Range (min … max):   653.1 ms … 710.8 ms    10 runs
```
So it is even faster (~10%) because it foregoes all the Cython stuff, but this comes at a cost of much verbose. We have already discussed this and dumping Cython which you are very familiar with, for a verbose C code base that is more difficult to maintain is not helpful. Having the speed difference down to 10% makes it definitely not worth the switch. (Still I prefer C for my own projects as getting Cython to do the things I actually want has been quite an annoying and time-consuming process ;-). But finally, that is now finished for dnaio.)