### PR TITLE
Avoid running CI jobs twice

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,10 @@ on: [push, pull_request]
 
 jobs:
   lint:
+    # Run for PRs only if they come from a forked repo (avoids duplicate runs)
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     timeout-minutes: 10
     runs-on: ubuntu-latest
     strategy:
@@ -22,6 +26,9 @@ jobs:
       run: tox -e ${{ matrix.toxenv }}
 
   build:
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
@@ -35,6 +42,9 @@ jobs:
         path: dist/*.tar.gz
 
   test:
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     timeout-minutes: 10
     runs-on: ${{ matrix.os }}
     strategy:


### PR DESCRIPTION
Jobs are triggered twice if they are pushed to the repo and if they are part of a pull request. With this, a job belonging to a pull request is only run if it comes from a forked repository.

Derived from
https://wildwolf.name/github-actions-how-to-avoid-running-the-same-workflow-multiple-times/, (but typos fixed)

(It would be nicer if GitHub just handled this automatically.)