### PR TITLE
Add build.os key to Read the Docs configuration

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,5 +1,8 @@
 version: 2
-
+build:
+  os: "ubuntu-22.04"
+  tools:
+    python: "3.11"
 python:
   install:
   - requirements: doc/requirements.txt


### PR DESCRIPTION
This will be required soon, see https://blog.readthedocs.com/use-build-os-config/