### PR TITLE
Bump cibuildwheel so that wheels for Python 3.12 get built

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,7 @@ jobs:
       uses: pypa/cibuildwheel@v2.16.2
       env:
         CIBW_BUILD: "cp*-manylinux_x86_64 cp3*-win_amd64 cp3*-macosx_x86_64"
+        CIBW_SKIP: "cp37-*"
     - uses: actions/upload-artifact@v3
       with:
         name: wheels

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,7 @@ jobs:
       with:
         fetch-depth: 0  # required for setuptools_scm
     - name: Build wheels
-      uses: pypa/cibuildwheel@v2.11.2
+      uses: pypa/cibuildwheel@v2.16.2
       env:
         CIBW_BUILD: "cp*-manylinux_x86_64 cp3*-win_amd64 cp3*-macosx_x86_64"
     - uses: actions/upload-artifact@v3


### PR DESCRIPTION
Also, do not build wheels for Python 3.7 as it is end of life.

I tested this locally with this command:
```bash
CIBW_SKIP="cp37-*" CIBW_BUILD="cp*-manylinux_x86_64 cp3*-win_amd64 cp3*-macosx_x86_64" pipx run cibuildwheel==2.16.2 --platform=linux
```
which created these wheels:
```
dnaio-1.0.1.dev9+g7420fee-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl   93 kB
dnaio-1.0.1.dev9+g7420fee-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl   94 kB
dnaio-1.0.1.dev9+g7420fee-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl   91 kB
dnaio-1.0.1.dev9+g7420fee-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl     94 kB
dnaio-1.0.1.dev9+g7420fee-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl     94 kB
```