### PR TITLE
Add asan tox environment for testing memory errors

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -38,7 +38,7 @@ setenv=
     CFLAGS=-lasan -fsanitize=address -fno-omit-frame-pointer
 allowlist_externals=bash
 commands=
-    bash -c 'export LD_PRELOAD=$(find /usr/lib -name "libasan.so*" | head -n 1) && printenv LD_PRELOAD && python -c "import dnaio" && pytest tests'
+    bash -c 'export LD_PRELOAD=$(gcc -print-file-name=libasan.so) && printenv LD_PRELOAD && python -c "import dnaio" && pytest tests'
 
 [testenv:docs]
 basepython = python3.10

--- a/tox.ini
+++ b/tox.ini
@@ -31,6 +31,15 @@ deps =
     pytest
 commands = mypy src/ tests/
 
+[testenv:asan]
+setenv=
+    PYTHONDEVMODE=1
+    PYTHONMALLOC=malloc
+    CFLAGS=-lasan -fsanitize=address -fno-omit-frame-pointer
+allowlist_externals=bash
+commands=
+    bash -c 'export LD_PRELOAD=$(find /usr/lib -name "libasan.so*" | head -n 1) && printenv LD_PRELOAD && python -c "import dnaio" && pytest tests'
+
 [testenv:docs]
 basepython = python3.10
 changedir = doc


### PR DESCRIPTION
None were found. Unfortunately the environment cannot run on github CI. This might be useful for some of your other projects. I just managed to remove two memory errors from python-isal. They were in exception paths, nothing major, but still nice.