### PR TITLE
Highlight xopen's Zstandard support when optionally installed

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -39,7 +39,7 @@ Features and supported file types
 - FASTQ input and output
 - FASTA input and output
 - BAM input
-- Compressed input and output (``.gz``, ``.bz2`` and ``.xz``, detected automatically)
+- Compressed input and output (``.gz``, ``.bz2``, ``.xz`` and ``.zst`` are detected automatically; z)
 - Paired-end data in two files
 - Interleaved paired-end data in a single file
 - Files with DOS/Windows linebreaks can be read
@@ -50,6 +50,8 @@ Limitations
 
 - Multi-line FASTQ files are not supported.
 - FASTQ and BAM parsing is the focus of this library. The FASTA parser is not as optimized.
+- For reading and writing Zstandard (``.zst``) files, either the ``zstd`` command-line
+program or the Python ``zstandard`` package needs to be installed.
 
 Links
 =====

--- a/README.rst
+++ b/README.rst
@@ -50,8 +50,7 @@ Limitations
 
 - Multi-line FASTQ files are not supported.
 - FASTQ and BAM parsing is the focus of this library. The FASTA parser is not as optimized.
-- For reading and writing Zstandard (``.zst``) files, either the ``zstd`` command-line
-program or the Python ``zstandard`` package needs to be installed.
+- For reading and writing Zstandard (``.zst``) files, either the ``zstd`` command-line program or the Python ``zstandard`` package needs to be installed.
 
 Links
 =====

--- a/README.rst
+++ b/README.rst
@@ -39,7 +39,7 @@ Features and supported file types
 - FASTQ input and output
 - FASTA input and output
 - BAM input
-- Compressed input and output (``.gz``, ``.bz2``, ``.xz`` and ``.zst`` are detected automatically; z)
+- Compressed input and output (``.gz``, ``.bz2``, ``.xz`` and ``.zst`` are detected automatically)
 - Paired-end data in two files
 - Interleaved paired-end data in a single file
 - Files with DOS/Windows linebreaks can be read

--- a/README.rst
+++ b/README.rst
@@ -50,7 +50,8 @@ Limitations
 
 - Multi-line FASTQ files are not supported.
 - FASTQ and BAM parsing is the focus of this library. The FASTA parser is not as optimized.
-- For reading and writing Zstandard (``.zst``) files, either the ``zstd`` command-line program or the Python ``zstandard`` package needs to be installed.
+- For reading and writing Zstandard (``.zst``) files, either the ``zstd`` command-line
+  program or the Python ``zstandard`` package needs to be installed.
 
 Links
 =====

--- a/README.rst
+++ b/README.rst
@@ -33,6 +33,15 @@ The main interface is the `dnaio.open <https://dnaio.readthedocs.io/en/latest/ap
 For more, see the `tutorial <https://dnaio.readthedocs.io/en/latest/tutorial.html>`_ and
 `API documentation <https://dnaio.readthedocs.io/en/latest/api.html>`_.
 
+Installation
+============
+
+Using pip:: 
+
+    pip install dnaio zstandard
+
+``zstandard`` can be omitted if support for Zstandard (``.zst``) files is not required.
+
 Features and supported file types
 =================================
 
@@ -48,10 +57,8 @@ Features and supported file types
 Limitations
 ===========
 
-- Multi-line FASTQ files are not supported.
-- FASTQ and BAM parsing is the focus of this library. The FASTA parser is not as optimized.
-- For reading and writing Zstandard (``.zst``) files, either the ``zstd`` command-line
-  program or the Python ``zstandard`` package needs to be installed.
+- Multi-line FASTQ files are not supported
+- FASTQ and BAM parsing is the focus of this library. The FASTA parser is not as optimized
 
 Links
 =====

--- a/src/dnaio/readers.py
+++ b/src/dnaio/readers.py
@@ -33,7 +33,7 @@ class BinaryFileReader:
     ):
         """
         The file is a path or a file-like object. In both cases, the file may
-        be compressed (.gz, .bz2, .xz).
+        be compressed (.gz, .bz2, .xz, .zst).
         """
         if isinstance(file, str):
             self._file = opener(file, self.mode)
@@ -80,7 +80,7 @@ class FastaReader(BinaryFileReader, SingleEndReader):
     ):
         """
         file is a path or a file-like object. In both cases, the file may
-        be compressed (.gz, .bz2, .xz).
+        be compressed (.gz, .bz2, .xz, .zst).
 
         keep_linebreaks -- whether to keep newline characters in the sequence
         """


### PR DESCRIPTION
Hi, what a fantastically useful library this is! I particularly like that it supports stdin and Zstandard compression.

This tiny PR highlights underlying xopen's (and therefore dnaio's) existing support for `.zst` extensions, mentioning that either of two dependencies (`zstd` CLI or `Zstandard` PyPI package) must be installed to make it work.