### PR TITLE
Using memcmp with a fixed length leads to very efficient assembly

### DIFF
--- a/src/dnaio/_core.pyx
+++ b/src/dnaio/_core.pyx
@@ -591,7 +591,7 @@ cdef class FastqIter:
             second_header_start = sequence_end + 1
             remaining_bytes = (buffer_end - second_header_start)
             # Usually there is no second header, so we skip the memchr call.
-            if remaining_bytes > 2 and second_header_start[0] == b'+' and second_header_start[1] == b'\n':
+            if remaining_bytes > 2 and memcmp(second_header_start, b"+\n", 2) == 0:
                 second_header_end = second_header_start + 1
             else:
                 second_header_end = <char *>memchr(second_header_start, b'\n', <size_t>(remaining_bytes))


### PR DESCRIPTION
This is inconsequential except that it leads to slightly cleaner code and slightly cleaner assembly. In this case the compiler will turn it into a direct comparison of two 16 bit integers, rather than comparing the characters individually. 
Since the branch is very predictable, there is no performance impact. 