### PR TITLE
Add citation info

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,14 @@
+cff-version: 1.2.0
+title: dnaio
+type: software
+authors:
+  - given-names: Marcel
+    family-names: Martin
+    orcid: 'https://orcid.org/0000-0002-0680-200X'
+  - given-names: Ruben
+    name-particle: H P
+    family-names: Vorderman
+    orcid: 'https://orcid.org/0000-0002-8813-1528'
+repository-code: 'https://github.com/marcelm/dnaio/'
+url: 'https://dnaio.readthedocs.io/'
+license: MIT

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -5,8 +5,7 @@ authors:
   - given-names: Marcel
     family-names: Martin
     orcid: 'https://orcid.org/0000-0002-0680-200X'
-  - given-names: Ruben
-    name-particle: H P
+  - given-names: Ruben Harmen Paul
     family-names: Vorderman
     orcid: 'https://orcid.org/0000-0002-8813-1528'
 identifiers:

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -9,6 +9,9 @@ authors:
     name-particle: H P
     family-names: Vorderman
     orcid: 'https://orcid.org/0000-0002-8813-1528'
+identifiers:
+  - type: doi
+    value: 10.5281/zenodo.10548864
 repository-code: 'https://github.com/marcelm/dnaio/'
 url: 'https://dnaio.readthedocs.io/'
 license: MIT

--- a/README.rst
+++ b/README.rst
@@ -1,3 +1,6 @@
+.. image:: https://zenodo.org/badge/DOI/10.5281/zenodo.10548864.svg
+  :target: https://doi.org/10.5281/zenodo.10548864
+
 .. image:: https://github.com/marcelm/dnaio/workflows/CI/badge.svg
     :alt: GitHub Actions badge
 
@@ -36,7 +39,7 @@ For more, see the `tutorial <https://dnaio.readthedocs.io/en/latest/tutorial.htm
 Installation
 ============
 
-Using pip:: 
+Using pip::
 
     pip install dnaio zstandard
 


### PR DESCRIPTION
This adds a `CITATION.cff` file. I used Zenodo to generate DOIs.

The DOI listed in `CITATION.cff` and linked to in the badge is the "all versions" DOI: https://zenodo.org/doi/10.5281/zenodo.10548864

The DOI specific to version 1.2.0 is this one: https://zenodo.org/doi/10.5281/zenodo.10548865

Zenodo recommends using the more specific one, but I am reluctant to do so because that would require that we update the `CITATION.cff` file for each release, and also that we enable GitHub releases.

CC @DongzeHE 

Closes #127