### PR TITLE
Build macOS arm64 wheels

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,16 +81,16 @@ jobs:
     timeout-minutes: 15
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest, macos-13, macos-14]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4
       with:
         fetch-depth: 0  # required for setuptools_scm
     - name: Build wheels
-      uses: pypa/cibuildwheel@v2.16.2
+      uses: pypa/cibuildwheel@v2.17.0
       env:
-        CIBW_BUILD: "cp*-manylinux_x86_64 cp3*-win_amd64 cp3*-macosx_x86_64"
+        CIBW_BUILD: "cp*-manylinux_x86_64 cp3*-win_amd64 cp3*-macosx_x86_64 cp3*-macosx_arm64"
         CIBW_SKIP: "cp37-*"
     - uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,9 @@ jobs:
     - name: Test
       run: tox -e py
     - name: Upload coverage report
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v4
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
 
   wheels:
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,7 @@ jobs:
       env:
         CIBW_BUILD: "cp*-manylinux_x86_64 cp3*-win_amd64 cp3*-macosx_x86_64 cp3*-macosx_arm64"
         CIBW_SKIP: "cp37-*"
+        CIBW_TEST_SKIP: "cp38-macosx_*:arm64"
     - uses: actions/upload-artifact@v4
       with:
         name: wheels-${{ matrix.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
         os: [ubuntu-latest]
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
         include:
-        - os: macos-latest
+        - os: macos-13
           python-version: "3.10"
         - os: macos-14
           python-version: "3.10"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,7 @@ jobs:
         CIBW_SKIP: "cp37-*"
     - uses: actions/upload-artifact@v4
       with:
-        name: wheels
+        name: wheels-${{ matrix.os }}
         path: wheelhouse/*.whl
 
   publish:
@@ -102,14 +102,15 @@ jobs:
     needs: [build, wheels]
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: sdist
         path: dist/
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
-        name: wheels
+        pattern: wheels-*
         path: dist/
+        merge-multiple: true
     - name: Publish to PyPI
       uses: pypa/gh-action-pypi-publish@v1.5.1
       with:


### PR DESCRIPTION
Also:
- Fix codecov uploads
- Bump upload-action (and ensure unique artifact names, which is now a requirement)
- Test on both macos-13 (x86_64) and macos-14 (arm64)

Successful run (with the check whether CI is running for a tag commented out): https://github.com/marcelm/dnaio/actions/runs/8800496451