### PR TITLE
s/d/_core.pyx: pedantic typo caught by linting.

### DIFF
--- a/src/dnaio/_core.pyx
+++ b/src/dnaio/_core.pyx
@@ -843,7 +843,7 @@ cdef class BamIter:
 def record_names_match(header1: str, header2: str):
     """
     Check whether the sequence record ids id1 and id2 are compatible, ignoring a
-    suffix of '1', '2' or '3'. This exception allows to check some old
+    suffix of '1', '2' or '3'. This exception allows one to check some old
     paired-end reads that have IDs ending in '/1' and '/2'. Also, the
     fastq-dump tool (used for converting SRA files to FASTQ) appends '.1', '.2'
     and sometimes '.3' to paired-end reads if option -I is used.


### PR DESCRIPTION
Debian's linting tool "lintian" reports the below informational message in dnaio 1.2.2 (and possibly other versions):

	I: python3-dnaio: spelling-error-in-binary "allows to" "allows one to" [usr/lib/python3/dist-packages/dnaio/_core.cpython-312-x86_64-linux-gnu.so]

This patch applies almost blindly the recommendation, although perhaps there exists better wording to apply to the desctiption of the symbol. For what it's worth, I did attempt to find better wording, but lacking proper context for the function, the recommended change might do.