### PR TITLE
Ignore complex mypy issue

### DIFF
--- a/src/dnaio/multipleend.py
+++ b/src/dnaio/multipleend.py
@@ -202,7 +202,7 @@ class MultipleFastqWriter(MultipleFileWriter):
         self._stack = contextlib.ExitStack()
         self._writers: List[IO] = [
             self._stack.enter_context(
-                opener(file, mode + "b") if not hasattr(file, "write") else file
+                opener(file, mode + "b") if not hasattr(file, "write") else file  # type: ignore
             )
             for file in self._files
         ]


### PR DESCRIPTION
The original error:

```
src/dnaio/multipleend.py:205: error: Argument 1 to "enter_context" of "ExitStack" has incompatible type "Any | str | PathLike[Any] | BinaryIO"; expected "AbstractContextManager[IO[Any], bool | None]"  [arg-type]
Found 1 error in 1 file (checked 12 source files
```


