### PR TITLE
Support Python 3.13; drop support for Python 3.8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
         include:
         - os: macos-13
           python-version: "3.10"
@@ -88,7 +88,7 @@ jobs:
       with:
         fetch-depth: 0  # required for setuptools_scm
     - name: Build wheels
-      uses: pypa/cibuildwheel@v2.17.0
+      uses: pypa/cibuildwheel@v2.21.3
       env:
         CIBW_BUILD: "cp*-manylinux_x86_64 cp3*-win_amd64 cp3*-macosx_x86_64 cp3*-macosx_arm64"
         CIBW_SKIP: "cp37-*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
         include:
         - os: macos-13
           python-version: "3.10"
@@ -91,8 +91,6 @@ jobs:
       uses: pypa/cibuildwheel@v2.21.3
       env:
         CIBW_BUILD: "cp*-manylinux_x86_64 cp3*-win_amd64 cp3*-macosx_x86_64 cp3*-macosx_arm64"
-        CIBW_SKIP: "cp37-*"
-        CIBW_TEST_SKIP: "cp38-macosx_*:arm64"
     - uses: actions/upload-artifact@v4
       with:
         name: wheels-${{ matrix.os }}

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,11 @@
 Changelog
 =========
 
+unreleased
+----------
+
+* Added support for Python 3.13
+
 v1.2.2 (2024-10-04)
 -------------------
 * :pr:`139`: Fix an error that occurred when decoding BAM records with missing

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ unreleased
 ----------
 
 * Added support for Python 3.13
+* Dropped support for Python 3.8
 
 v1.2.2 (2024-10-04)
 -------------------

--- a/README.rst
+++ b/README.rst
@@ -16,7 +16,7 @@
 dnaio processes FASTQ, FASTA and uBAM files
 ===========================================
 
-``dnaio`` is a Python 3.8+ library for very efficient parsing and writing of FASTQ and also FASTA files.
+``dnaio`` is a Python 3.9+ library for very efficient parsing and writing of FASTQ and also FASTA files.
 Since ``dnaio`` version 1.1.0, support for efficiently parsing uBAM files has been implemented.
 This allows reading ONT files from the `dorado <https://github.com/nanoporetech/dorado>`_
 basecaller directly.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
     "Programming Language :: Python :: 3",
     "Topic :: Scientific/Engineering :: Bio-Informatics"
 ]
-requires-python = ">3.7"
+requires-python = ">=3.9"
 dependencies = [
     "xopen >= 1.4.0"
 ]

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = flake8,black,mypy,docs,py38,py39,py310,py311,py312
+envlist = flake8,black,mypy,docs,py38,py39,py310,py311,py312,py313
 isolated_build = True
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = flake8,black,mypy,docs,py38,py39,py310,py311,py312,py313
+envlist = flake8,black,mypy,docs,py39,py310,py311,py312,py313
 isolated_build = True
 
 [testenv]


### PR DESCRIPTION
I’d like to make Python 3.13 wheels available. I suggest to merge this PR and then release 1.2.3.