### PR TITLE
Fix failing test on Windows with Python 3.11.9+

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,16 +49,12 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-latest, windows-latest]
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
         include:
         - os: macos-13
           python-version: "3.10"
         - os: macos-14
-          python-version: "3.10"
-        - os: windows-latest
-          python-version: "3.10"
-        - os: ubuntu-latest
           python-version: "3.10"
     steps:
     - uses: actions/checkout@v4

--- a/src/dnaio/singleend.py
+++ b/src/dnaio/singleend.py
@@ -126,13 +126,13 @@ def _detect_format_from_content(file: BinaryIO) -> Optional[str]:
     """
     Return 'fasta', 'fastq' or None
     """
-    if file.seekable():
+    if hasattr(file, "peek"):
+        magic = file.peek(4)[0:4]
+    else:
+        # We cannot always use peek() because BytesIO objects do not suppert it
         original_position = file.tell()
         magic = file.read(4)
         file.seek(original_position)
-    else:
-        # We cannot always use peek() because BytesIO objects do not suppert it
-        magic = file.peek(4)[0:4]  # type: ignore
     if magic.startswith(b"@") or magic == b"":
         # Pretend FASTQ for empty input
         return "fastq"


### PR DESCRIPTION
Python 3.10 is fine, but 3.11 breaks the tests. This made creating the wheels for v1.2.3 fail.