### PR TITLE
Test limited API

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,10 +10,18 @@ if platform.machine() == "AMD64":
 else:
     DEFINE_MACROS = []
 
+DEFINE_MACROS += [
+    ("CYTHON_LIMITED_API", 1),
+    ("Py_Limited_API", 0x030C0000),
+]
+
 setup(
     ext_modules=[
         Extension(
-            "dnaio._core", sources=["src/dnaio/_core.pyx"], define_macros=DEFINE_MACROS
+            "dnaio._core",
+            sources=["src/dnaio/_core.pyx"],
+            define_macros=DEFINE_MACROS,
+            py_limited_api=True,
         ),
     ],
 )


### PR DESCRIPTION
After watching
https://ep2024.europython.eu/session/cython-and-the-limited-api/, I wanted to test how well switching to the stable ABI would work.

It would be great to be able to build a single wheel for each platform and not have to update when a new Python version gets released.

There are two issues. The first is that using the limited API makes dnaio slower. Reading FASTQ files takes 50% more time. I did not benchmark anything else. It was actually about 10 time slower when I used the limited API for Python 3.7. (This PR uses what is available in Python 3.12.) Maybe this will get better in newer versions.

The second issue is that still some non-ABI3 symbols are being used in our code, in particular PyUnicode_New.

abi3audit (https://github.com/pypa/abi3audit) outputs this:

```
$ abi3audit -v --assume-minimum-abi3 3.12 src/dnaio/_core.abi3.so
[09:47:43] 👎 : _core.abi3.so has non-ABI3 symbols
           ┏━━━━━━━━━━━━━━━━━━━━━━━━━┓
           ┃ Symbol                  ┃
           ┡━━━━━━━━━━━━━━━━━━━━━━━━━┩
           │ PyUnicode_New           │
           │ Py_CompileStringExFlags │
           │ _Py_FatalErrorFunc      │
           └─────────────────────────┘
           💁 _core.abi3.so: 1 extensions scanned; 0 ABI version mismatches and 3 ABI violations found
```

~~This PR is just meant to document the experiment, so I’ll close it right away.~~