### PR TITLE
Fix Read the Docs configuration

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -3,6 +3,8 @@ build:
   os: "ubuntu-22.04"
   tools:
     python: "3.11"
+sphinx:
+  configuration: "doc/conf.py"
 python:
   install:
   - requirements: doc/requirements.txt


### PR DESCRIPTION
https://about.readthedocs.com/blog/2024/12/deprecate-config-files-without-sphinx-or-mkdocs-config/