### PR TITLE
Fix unoptimized wheels

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,17 +45,18 @@ write_to = "src/dnaio/_version.py"
 testpaths = ["tests"]
 
 [tool.cibuildwheel.windows.environment]
-CFLAGS = "-g0 -DNDEBUG"
+CFLAGS = "-O3 -DNDEBUG"
 
 [tool.cibuildwheel.macos.environment]
-CFLAGS = "-g0 -DNDEBUG"
+CFLAGS = "-O3 -DNDEBUG"
 
 [tool.cibuildwheel.linux.environment]
-CFLAGS = "-g0 -DNDEBUG"
+CFLAGS = "-O3 -DNDEBUG"
 
 [tool.cibuildwheel]
 test-requires = "pytest"
 test-command = ["cd {project}", "pytest tests"]
+build-verbosity = 1
 
 [[tool.cibuildwheel.overrides]]
 select = "*-win*"


### PR DESCRIPTION
setuptools starting from version 75.7.0 changed how CFLAGS work: They no longer are added to the CFLAGS Python was compiled with, but replace them.

With this change, our CFLAGS of `-g0 -DNDEBUG` get used directly and the wheels are compiled without proper optimizations because `-O2` is missing.

Within cibuildwheel, the Python compiler options that we "lose" by this change are:

    -fno-strict-overflow -Wsign-compare -DNDEBUG -g -O3 -Wall

Of these, we really only require `-O3` and `-DNDEBUG`, so the easiest fix should be to just add `-O3` to the CFLAGS that we provide.

Found by @rhpvorderman in https://github.com/marcelm/cutadapt/issues/843