### PR TITLE
Remove macos-13 runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
         include:
         - os: macos-latest
           python-version: "3.10"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,9 +52,7 @@ jobs:
         os: [ubuntu-latest, windows-latest]
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
         include:
-        - os: macos-13
-          python-version: "3.10"
-        - os: macos-14
+        - os: macos-latest
           python-version: "3.10"
     steps:
     - uses: actions/checkout@v4
@@ -77,7 +75,7 @@ jobs:
     timeout-minutes: 15
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-13, macos-14]
+        os: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4

--- a/README.rst
+++ b/README.rst
@@ -16,7 +16,7 @@
 dnaio processes FASTQ, FASTA and uBAM files
 ===========================================
 
-``dnaio`` is a Python 3.9+ library for very efficient parsing and writing of FASTQ and also FASTA files.
+``dnaio`` is a Python 3 library for very efficient parsing and writing of FASTQ and also FASTA files.
 Since ``dnaio`` version 1.1.0, support for efficiently parsing uBAM files has been implemented.
 This allows reading ONT files from the `dorado <https://github.com/nanoporetech/dorado>`_
 basecaller directly.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ classifiers = [
     "Programming Language :: Python :: 3",
     "Topic :: Scientific/Engineering :: Bio-Informatics"
 ]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dependencies = [
     "xopen >= 1.4.0"
 ]

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = flake8,black,mypy,docs,py39,py310,py311,py312,py313
+envlist = flake8,black,mypy,docs,py310,py311,py312,py313
 isolated_build = True
 
 [testenv]


### PR DESCRIPTION
It will soon stop working. Also, drop Python 3.9, which will reach end-of-life this month.